### PR TITLE
Add chat box support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+venv/
+ENV/
+build/
+dist/
+*.egg-info/
+# Pygame window config
+*.log
+SavedGames/
+Images/*.png
+!Images/.gitkeep
+sounds/*
+!sounds/.gitkeep
+test_nodes*/

--- a/README.md
+++ b/README.md
@@ -1,13 +1,26 @@
-# HoloLive-Colleseum
-IDK arena. Shoutout gawr gura
+# Hololive Coliseum
+Prototype platform fighter featuring Hololive VTubers.
+All playable characters extend a common `PlayerCharacter` class providing
+movement, combat actions and resource tracking. The roster currently includes
+twenty-one selectable characters displayed in a grid on the character select screen.
+The repository goals are detailed in [docs/GOALS.md](docs/GOALS.md).
+Story mode chapters are outlined in [docs/DEV_PLAN_STORY.md](docs/DEV_PLAN_STORY.md).
+Networking details live in [docs/DEV_PLAN_NETWORK.md](docs/DEV_PLAN_NETWORK.md).
 
 
-List of Required Assets
+## Asset Placeholders
+The repository references simple placeholder images and a sound effect so the game runs without additional downloads. The PNG and WAV files are not included.
+
 Directories
-./SavedGames
-./Images
-./sounds
+- `SavedGames/`
+- `Images/`
+- `sounds/`
+The `SavedGames` folder stores settings in `settings.json`. Selecting "Wipe Saves" from the settings menu clears this directory.
+If the folder is missing, it will be recreated automatically the next time settings are saved.
+The file also tracks your best survival time and high score so far.
+
 Images (PNGs)
+```
 ./Images/Watson_Amelia_right.png
 ./Images/Watson_Amelia_left.png
 ./Images/Gawr_Gura_right.png
@@ -28,11 +41,291 @@ Images (PNGs)
 ./Images/Nanashi_Mumei_left.png
 ./Images/Hakos_Baelz_right.png
 ./Images/Hakos_Baelz_left.png
+./Images/Shirakami_Fubuki_right.png
+./Images/Shirakami_Fubuki_left.png
+./Images/Sakura_Miko_right.png
+./Images/Sakura_Miko_left.png
+./Images/Minato_Aqua_right.png
+./Images/Minato_Aqua_left.png
+./Images/Usada_Pekora_right.png
+./Images/Usada_Pekora_left.png
+./Images/Houshou_Marine_right.png
+./Images/Houshou_Marine_left.png
+./Images/Hoshimachi_Suisei_right.png
+./Images/Hoshimachi_Suisei_left.png
+./Images/Nakiri_Ayame_right.png
+./Images/Nakiri_Ayame_left.png
+./Images/Shirogane_Noel_right.png
+./Images/Shirogane_Noel_left.png
+./Images/Shiranui_Flare_right.png
+./Images/Shiranui_Flare_left.png
+./Images/Oozora_Subaru_right.png
+./Images/Oozora_Subaru_left.png
+./Images/Tokino_Sora_right.png
+./Images/Tokino_Sora_left.png
 ./Images/character_right.png
 ./Images/character_left.png
 ./Images/enemy_right.png
 ./Images/enemy_left.png
 ./Images/boss_right.png
 ./Images/boss_left.png
+./Images/map_default.png
+./Images/chapter1.png
+./Images/chapter2.png
+./Images/chapter3.png
+./Images/chapter4.png
+./Images/chapter5.png
+./Images/chapter6.png
+./Images/chapter7.png
+./Images/chapter8.png
+./Images/chapter9.png
+./Images/chapter10.png
+./Images/chapter11.png
+./Images/chapter12.png
+./Images/chapter13.png
+./Images/chapter14.png
+./Images/chapter15.png
+./Images/chapter16.png
+./Images/chapter17.png
+./Images/chapter18.png
+./Images/chapter19.png
+./Images/chapter20.png
+```
+
 Audio Tracks
-./sounds/collision.wav
+(no audio files included)
+
+## Running the Prototype
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Launch the game:
+   ```bash
+   python -m hololive_coliseum
+   ```
+
+The current prototype includes a basic player with gravity, health and mana bars,
+ a cyan splash screen leading to a simple menu system. Combat features melee attacks with **X**, projectile shooting with **Z**, blocking with **Shift**, a parry on **C**, and quick dodges with **Left Ctrl**. A low-gravity zone reduces gravity so jumps carry the player higher while a high-gravity zone increases gravity to limit movement. Spike traps now inflict damage on contact, icy patches lower friction and lava pits deal damage over time. Enemies attempt to jump over these hazards.
+Movement now uses acceleration and friction for smoother platforming.
+Characters can also perform a double jump before landing for extra mobility.
+Menu navigation now includes character, map, and chapter selection screens with
+grid layouts and **Back** buttons for easy navigation. The map selector displays
+tiles in the same 5×4 grid used for characters. During offline multiplayer character
+selection a **"Press J to join"** prompt allows additional local players to join,
+ and an **Add AI Player** option lets you fill extra slots with simple bots in
+ either solo or multiplayer. A **Difficulty** entry cycles between Easy,
+Normal and Hard to tune AI behavior. Selected AI players now spawn as enemies that
+  chase the human player. Enemy AI adjusts reaction time and attack frequency
+ depending on difficulty, using projectiles and melee swings when near. They will also dodge incoming shots on higher levels. Projectiles and melee attacks damage enemies on contact, and enemies hurt the player when touching them. Press **V** to use Gura's special trident attack,
+Watson's time-dash, Ina's tentacle grapple, Kiara's fiery dive, Calliope's returning scythe, Fauna's healing field, Fubuki's freezing shard, Miko's piercing beam, Mumei's slowing flock, Kronii's extended parry, IRyS's crystal shield, Baelz's chaos effect, Aqua's water blast, Pekora's explosive carrot, Marine's anchor boomerang, Suisei's piercing star, Ayame's swift dash, Noel's ground slam, Flare's flame burst, Subaru's stunning blast, Sora's uplifting melody, or other character abilities during gameplay. Projectiles can be aimed with the mouse and the special attack
+fires an exploding shot. A status effect manager tracks temporary effects such as freezing or slowing enemies when these abilities land. A skill manager coordinates ability cooldowns so each character registers its unique special once. An **AIManager** directs enemy behavior while an **NPCManager** organizes enemy and ally groups. An **AllyManager** keeps friendly NPCs active. Powerups periodically spawn to restore health or mana, and an **InventoryManager** stores collected items, while a **QuestManager** tracks objectives and an **AchievementManager** records milestones. A simple life counter, level timer and enemy score are displayed. A revamped **Settings**
+menu features key and controller binding editors managed by a **KeybindManager**, volume adjustments,
+ window-size toggling, an option to toggle an FPS counter, and a save-wipe option
+ so preferences persist across sessions. You can also reset your best time and
+ score. A new **Node Settings** entry lets advanced users start hosting a
+blockchain node or stop hosting at any time. An **Accounts** submenu allows
+registering or deleting the current player account. Press **Esc** during
+gameplay to open a pause menu with options to resume or return to the main
+menu. Press **Enter** to open an in-game chat box and coordinate with other
+players. Menus are outlined with a teal border for a cleaner look. The main menu
+also features **How to Play** and **Credits** options describing the controls
+and acknowledging contributors. Selecting
+multiplayer now leads
+to a lobby screen listing every joined human and AI player before the map menu
+appears.
+Losing all lives transitions to a **Game Over** screen that shows your time
+survived, total score, and the best run and high score. After a short pause the screen reveals
+**Play Again** and **Main Menu** buttons. Play Again jumps back to the character
+selection so you can quickly start another run.
+Defeating all enemies or surviving the level timer displays a **Victory** screen
+with the same summary, including your best time and high score, and a brief delay before the options appear.
+
+A new **Records** entry on the main menu shows your best survival time and high
+score so far. When online, nodes broadcast these numbers so every player sees
+the latest records across the mesh.
+
+### Story Mode
+The single-player campaign follows Gura's growth from rookie idol to battle-tested hero.
+Twenty chapter icons appear in the chapter select menu, each representing a new location and challenge.
+Selecting an icon loads its corresponding map using the placeholder images listed above.
+Additional characters, maps, and features will be introduced over time.
+
+### Networking Prototype
+The package now contains a `NetworkManager` module that uses UDP sockets for
+lightweight communication. Hosts answer broadcast discovery packets so clients
+can automatically locate games on the local network. A separate
+`node_registry` module stores known server addresses in `SavedGames/nodes.json`
+alongside a small set of built-in nodes. When a host starts it registers its
+address in this file and can broadcast an `announce` packet to share its
+location with other nodes. Clients maintain their own registry and add entries
+whenever they receive an `announce` message. When connecting online the game
+ pings all known nodes and chooses the one with the lowest latency. Nodes also
+ act as lightweight routers: hosts register their match with nearby nodes and
+ clients query those routers to receive a list of available games. Router nodes
+ exchange `games_update` packets so each peer keeps the same set of available
+ matches and additionally share `clients_update` packets so each node knows
+ which users are currently online. State updates include a sequence number and
+ only transmit fields that changed using the lightweight `StateSync` delta
+system so packets remain small. When a shared secret is configured, packets
+also include an HMAC signature so nodes can discard tampered data. The menus
+include an online versus offline
+multiplayer option to choose whether to connect to discovered nodes or play
+locally.
+Packets are compressed using a holographic lithography method. Each message is
+converted to a pointcloud and split into two base64 strings for transmission,
+then reconstructed on receipt to keep bandwidth low. The encoded pointcloud
+contains four color-coded anchor points -- black at `(0,0,0)`, red at `(1,0,0)`,
+cyan at `(1,0,1)` and white at `(1,1,1)` -- so the receiver can determine the
+pointcloud bounds before decoding. The encoded pointcloud
+includes a SHA256 digest so corrupted data is ignored. Packets may also be
+XOR-encrypted with a shared key for an additional layer of privacy.
+Critical packets can be marked **reliable** so the sender will resend them
+until an acknowledgement is received, ensuring important updates are not lost
+even over an unreliable connection. Reliable packets now include an
+``importance`` value that increases the resend rate and retry count for
+critical messages.
+Nodes periodically prune unreachable peers from the registry so discovery
+remains accurate even as servers appear and disappear.
+Starting a node from the **Node Settings** menu turns the game into a host that
+shares blockchain updates and discovers peers to form an IP mesh. The same menu
+offers a **Stop Node** option to revert to client-only mode.
+Advanced users can also enable a **Latency Helper** option in Node Settings.
+When active, the client announces itself as a relay so other players can route
+traffic through the lowest‑latency path. Router nodes share their available
+relays and clients may send packets via these helpers if it shortens the route.
+Whenever a new best time or high score is achieved, the node broadcasts a
+``records_update`` packet so peers can merge the latest numbers into their own
+settings.
+
+### Game History Blockchain
+Every completed online match is recorded in a lightweight blockchain stored in
+`SavedGames/chain.json`. Each block contains the game ID, participating
+usernames, winner and an optional wager amount. Winners "mine" a block when a
+match ends and the block is shared with other nodes. Balances are tracked in
+`balances.json` so players can bet currency on matches. Utility functions allow
+searching the chain by game ID or user ID for features like leaderboards and
+friends lists. A helper `get_balance(user_id)` returns the currency total for
+any account. The blockchain can be verified for tampering and merged with
+longer chains received from peers so all nodes share the same history. Game
+records are only accepted if every player has a registered account so invalid
+user IDs cannot be added.
+
+Messages between players can also be stored in the chain. Each account
+registers a public key and an access level (user, mod or admin). Accounts can
+be removed later if needed. When a
+message is sent, it is encrypted with a random key that is wrapped twice:
+once with the recipient's public key and once with the admin key. This keeps
+chats private while still allowing moderators to decrypt abusive messages using
+the mixed key.
+
+## Project Structure
+
+This repository contains several directories and Python modules that make up the
+prototype.  The key paths are listed below with a short description of how they
+interact:
+
+Directories
+| Path | Purpose |
+| ---- | ------- |
+| `hololive_coliseum/` | Core game modules including the main loop, player classes and helpers. |
+| `docs/` | Development notes, goals and design plans. |
+| `tests/` | Pytest suite covering gameplay and systems. |
+| `Images/` | Placeholder sprites loaded by the game menus. |
+| `sounds/` | Placeholder location for sound effects (empty in repo). |
+| `SavedGames/` | Created at runtime to store `settings.json`. |
+
+Important files
+| Path | Called From | Calls |
+| ---- | ---------- | ----- |
+| `main.py` | Entry point script executed directly. | `hololive_coliseum.game.main` |
+| `hololive_coliseum/__init__.py` | Imported when using `hololive_coliseum` as a package. | Re-exports main classes from submodules. |
+| `hololive_coliseum/game.py` | Invoked by `main.py` or `python -m hololive_coliseum`. | Coordinates gameplay, settings and networking. |
+| `hololive_coliseum/menus.py` | Imported by `game.py`. | Renders splash and option menus. |
+| `hololive_coliseum/player.py` | Used by `game.py` to create players and enemies. | Imports `physics`, `projectile`, `melee_attack`. |
+| `hololive_coliseum/projectile.py` | Instantiated from `player.py` or `game.py`. | None (pure sprite logic). |
+| `hololive_coliseum/melee_attack.py` | Spawned from `player.py`. | None. |
+| `hololive_coliseum/hazards.py` | Loaded by `game.py` to place spike traps, ice zones and lava pits. | None. |
+| `hololive_coliseum/gravity_zone.py` | Used in `game.py` to create low‑gravity areas. | None. |
+| `hololive_coliseum/powerup.py` | Spawned by `game.py` during matches. | None. |
+| `hololive_coliseum/skill_manager.py` | Used by `player.py` to manage ability cooldowns. | None. |
+| `hololive_coliseum/health_manager.py` | Provides health tracking helpers used by `player.py`. | None. |
+| `hololive_coliseum/mana_manager.py` | Provides mana tracking helpers used by `player.py`. | None. |
+| `hololive_coliseum/stats_manager.py` | Returns STR, DEX and other stats with temporary modifiers. | None. |
+| `hololive_coliseum/experience_manager.py` | Tracks XP and levels up when thresholds are reached. | None. |
+| `hololive_coliseum/equipment_manager.py` | Stores equipped items for each player. | None. |
+| `hololive_coliseum/inventory_manager.py` | Tracks collected items. | None. |
+| `hololive_coliseum/quest_manager.py` | Manages active quests and progress. | None. |
+| `hololive_coliseum/achievement_manager.py` | Records unlocked achievements. | None. |
+| `hololive_coliseum/keybind_manager.py` | Holds configurable key mappings. | None. |
+| `hololive_coliseum/ai_manager.py` | Coordinates enemy decision making. | Used by `game.py` during play. |
+| `hololive_coliseum/npc_manager.py` | Holds enemy and ally sprite groups. | Used by `game.py` to organize NPCs. |
+| `hololive_coliseum/ally_manager.py` | Updates friendly NPCs that assist the player. | Called from `game.py` each frame. |
+| `hololive_coliseum/menu_manager.py` | Tracks menu selection and navigation. | Used by `game.py` when handling menus. |
+| `hololive_coliseum/game_state_manager.py` | Stores the current and previous game state. | Updated by `game.py` whenever the state changes. |
+| `hololive_coliseum/network.py` | Created by `game.py` when online play is chosen. | Uses UDP sockets for discovery, state and record sharing. |
+| `hololive_coliseum/state_sync.py` | Helper for delta-compressed state updates with sequence numbers. | None. |
+| `hololive_coliseum/holographic_compression.py` | Encodes packets into pointcloud base64 pairs with optional XOR encryption and digest verification. | None. |
+| `hololive_coliseum/node_registry.py` | Shared helper for tracking known server nodes. | Read/writes `SavedGames/nodes.json`. |
+| `hololive_coliseum/save_manager.py` | Called by `game.py` and tests to persist settings. | Reads/writes JSON in `SavedGames` and merges record updates from peers. |
+| `hololive_coliseum/accounts.py` | Used by the blockchain and tests. | Stores public keys and access levels and can delete accounts. |
+| `hololive_coliseum/combat_manager.py` | Manages turn order and engagement logic. | None. |
+| `hololive_coliseum/damage_manager.py` | Computes final damage after reductions. | None. |
+| `hololive_coliseum/threat_manager.py` | Tracks threat values for AI targeting. | None. |
+| `hololive_coliseum/loot_manager.py` | Generates loot from drop tables. | None. |
+| `hololive_coliseum/buff_manager.py` | Applies buffs and debuffs using the status effect system. | None. |
+| `hololive_coliseum/appearance_manager.py` | Stores selected skins per entity. | None. |
+| `hololive_coliseum/animation_manager.py` | Tracks animation states and frames. | None. |
+| `hololive_coliseum/name_manager.py` | Handles naming and renames for characters. | None. |
+| `hololive_coliseum/session_manager.py` | Maintains login sessions to prevent duplicates. | None. |
+| `hololive_coliseum/sync_manager.py` | Computes time offsets between clients. | None. |
+| `hololive_coliseum/instance_manager.py` | Creates and destroys gameplay instances. | None. |
+| `hololive_coliseum/patch_manager.py` | Records the current patch version. | None. |
+| `hololive_coliseum/auth_manager.py` | Validates logins and issues tokens. | None. |
+| `hololive_coliseum/cheat_detection_manager.py` | Flags suspicious behavior. | None. |
+| `hololive_coliseum/ban_manager.py` | Maintains banned account list. | None. |
+| `hololive_coliseum/data_protection_manager.py` | Provides simple XOR encryption. | None. |
+| `hololive_coliseum/logging_manager.py` | Collects log events. | None. |
+| `hololive_coliseum/ui_manager.py` | Tracks active UI elements. | None. |
+| `hololive_coliseum/notification_manager.py` | Queues in-game notifications. | None. |
+| `hololive_coliseum/input_manager.py` | Stores key and controller mappings. | None. |
+| `hololive_coliseum/accessibility_manager.py` | Toggles colorblind modes and fonts. | None. |
+| `hololive_coliseum/chat_manager.py` | Manages text chat messages and chat box state. | Used by `game.py` during matches. |
+| `hololive_coliseum/voice_chat_manager.py` | Tracks users in voice channels. | None. |
+| `hololive_coliseum/emote_manager.py` | Provides available emotes. | None. |
+| `hololive_coliseum/sound_manager.py` | Plays sound effects and music. | None. |
+| `hololive_coliseum/effect_manager.py` | Triggers particle effects. | None. |
+| `hololive_coliseum/script_manager.py` | Loads and stores small scripts. | None. |
+| `hololive_coliseum/localization_manager.py` | Provides basic text translation. | None. |
+| `hololive_coliseum/resource_manager.py` | Caches loaded assets. | None. |
+| `hololive_coliseum/cluster_manager.py` | Tracks nodes in a cluster. | None. |
+| `hololive_coliseum/matchmaking_manager.py` | Groups players for matches. | None. |
+| `hololive_coliseum/load_balancer_manager.py` | Chooses the least busy server. | None. |
+| `hololive_coliseum/migration_manager.py` | Handles player transfers between servers. | None. |
+| `hololive_coliseum/billing_manager.py` | Records purchases and subscriptions. | None. |
+| `hololive_coliseum/ad_manager.py` | Manages in-game ads. | None. |
+| `hololive_coliseum/api_manager.py` | Stores third-party API endpoints. | None. |
+| `hololive_coliseum/support_manager.py` | Tracks support tickets. | None. |
+| `hololive_coliseum/crafting_manager.py` | Handles crafting recipes. | None. |
+| `hololive_coliseum/profession_manager.py` | Tracks profession XP and levels. | None. |
+| `hololive_coliseum/trade_manager.py` | Manages item trades between players. | None. |
+| `hololive_coliseum/economy_manager.py` | Stores global item prices. | None. |
+| `hololive_coliseum/currency_manager.py` | Tracks player currency balances. | None. |
+| `hololive_coliseum/title_manager.py` | Unlocks and sets active titles. | None. |
+| `hololive_coliseum/reputation_manager.py` | Stores faction reputation. | None. |
+| `hololive_coliseum/friend_manager.py` | Maintains the friends list. | None. |
+| `hololive_coliseum/guild_manager.py` | Handles guild membership and ranks. | None. |
+| `hololive_coliseum/mail_manager.py` | Sends and retrieves player mail. | None. |
+| `hololive_coliseum/map_manager.py` | Stores available maps and the current one. | None. |
+| `hololive_coliseum/environment_manager.py` | Tracks weather and other environment settings. | None. |
+| `hololive_coliseum/spawn_manager.py` | Schedules NPC or item spawns. | None. |
+| `hololive_coliseum/event_manager.py` | Records triggered world events. | None. |
+| `hololive_coliseum/dungeon_manager.py` | Manages dungeon lockouts for players. | None. |
+| `hololive_coliseum/housing_manager.py` | Stores player housing data. | None. |
+| `hololive_coliseum/mount_manager.py` | Tracks mounts per player. | None. |
+| `hololive_coliseum/pet_manager.py` | Maintains collectible pets. | None. |
+| `hololive_coliseum/companion_manager.py` | Assigns companions to players. | None. |
+
+The tests import the modules above to verify behavior. Development documents in
+`docs/` describe goals and planning for future work.

--- a/docs/DEV_NOTES.md
+++ b/docs/DEV_NOTES.md
@@ -1,0 +1,419 @@
+# Development Notes
+
+## 2025-07-06
+- Switched prototype to use Pygame for quick iteration.
+- Implemented basic `Player` class with gravity, movement, and jumping.
+- Added ground platform to the `Game` loop and drawing logic.
+- Updated README project title and description.
+- Added simple test verifying player falls under gravity.
+
+## 2025-07-07
+- Generated placeholder character sprites and a sound effect.
+- Updated `Player` to load an image if provided.
+- Player in the game now uses the Gawr Gura sprite.
+- Documented assets in the README and ignored `SavedGames` folder.
+
+## 2025-07-08
+- Implemented projectile system and firing with Z key.
+- Player tracks facing direction and cooldown for shooting.
+- Added tests for projectile movement.
+- Restored full placeholder asset list in README.
+
+## 2025-07-09
+- Added `GravityZone` sprite and integrated a low-gravity area in the stage.
+- Player now adjusts gravity based on zone collisions.
+- Created unit test for gravity zones and updated existing tests to initialize pygame.
+
+## 2025-07-10
+- Implemented health and mana system for the `Player`.
+- Drawing routine now displays health and mana bars on screen.
+- Projectiles consume mana when fired and fail if insufficient.
+- Added tests covering damage, mana usage, and status bar drawing.
+
+## 2025-07-11
+- Added melee attack sprite and blocking mechanic to `Player`.
+- Game loop now handles melee attacks with the **X** key.
+- Updated README to document controls.
+
+## 2025-07-12
+- Implemented parry ability activated with the **C** key.
+- Replaced splash prompt with a menu system to start a new game.
+- Added navigation for game type, player count, character, and map selection.
+- Updated tests to cover parry logic.
+
+## 2025-07-13
+- Introduced map and chapter selection screens with placeholder images.
+- Added a unique trident special attack for Gura, triggered by **V**.
+- Created tests covering the new special attack.
+
+## 2025-07-14
+- Added `NetworkManager` with simple UDP sockets for upcoming multiplayer.
+- Documented networking prototype in README and exported manager in package.
+- Added unit test verifying send/receive between client and host.
+
+## 2025-07-15
+- Implemented broadcast-based server discovery mirroring Hive-style detection.
+- Added menu step to choose online or offline multiplayer.
+- Updated tests for discovery and menu options.
+
+## 2025-07-16
+- Completed settings menu with dynamic volume display and a new key-binding
+  editor.
+- Added states for editing controls and saving changes on exit.
+- Updated README accordingly.
+
+## 2025-07-17
+- Added placeholder icons for characters, maps and chapters so menus look nicer.
+- Character selection now displays AI count and a "Press J to join" prompt for
+  local multiplayer.
+- Added ability to add AI players from the character menu.
+## 2025-07-18
+- Added controller binding menu and saving of bindings
+- Projectiles now aim toward the mouse and Gura's special attack explodes
+- Added simple powerup spawns, level timer, and life system
+
+## 2025-07-19
+- Fixed crash when `settings.json` contains invalid JSON
+- Volume adjustments no longer raise errors if the mixer fails to initialize
+
+## 2025-07-20
+- `save_settings` now recreates the save directory if it was deleted.
+- Cleaned up a comment about the low-gravity zone.
+- Network tests close sockets to avoid resource warnings.
+
+## 2025-07-21
+- Added `WatsonPlayer` with a time-dash special attack.
+- Game now creates the player when a level starts so character selection matters.
+
+## 2025-07-22
+- Extended goals list with short- and long-term sections.
+- AI players selected in the menu now spawn as enemies that pursue the player.
+
+## 2025-07-23
+- Added projectile and melee collision detection so enemies take damage when hit.
+- Updated goals and development plan to mention combat collisions.
+
+## 2025-07-24
+- Enemies now deal contact damage to the player.
+- Updated goals and development plan accordingly.
+
+## 2025-07-25
+- Added a "Growing Up" storyline for single-player with twenty chapter icons.
+- Updated menus to list all chapters and load placeholder images.
+
+## 2025-07-26
+- Introduced `InaPlayer` with a tentacle grapple special attack.
+- Character list now includes Ninomae Ina'nis and chapter menu supports her image.
+- Collision logic pulls enemies toward the player when grapple projectile hits.
+
+## 2025-07-27
+- Refactored `Player` into `PlayerCharacter` and updated character subclasses.
+- Added difficulty selector (Easy/Normal/Hard) to character menu.
+- Researched Smash Bros AI which scales reaction time and randomness by level; plan to mimic this behavior.
+
+## 2025-07-28
+- Implemented three AI tiers that vary reaction delay and aggression.
+- Enemies now shoot and use melee attacks, marking their projectiles so
+  collisions damage the player.
+- Updated collision handling for these enemy attacks and added tests.
+
+## 2025-07-29
+- Added SpikeTrap and IceZone hazards with player and enemy interactions.
+- Extended Enemy AI to jump over hazards when possible.
+- Created placeholder subclasses for each Hololive member with unique specials.
+- Updated development plan and goals accordingly and added new tests.
+
+## 2025-07-30
+- Added `FubukiPlayer` with an ice shard that slows enemies.
+- Updated menus and image lists to include Shirakami Fubuki.
+- Documented the new ability in the development plan and goals.
+
+## 2025-07-31
+- Added volume cycling when selecting the option in the settings menu.
+- Documented project structure and file paths in README and notes.
+
+## 2025-08-01
+- Introduced a `node_registry` module storing known server addresses.
+- NetworkManager now registers hosts and handles `announce` messages to build a
+  mesh of user-hosted nodes.
+- Added a networking plan document and updated development plans and README.
+
+## 2025-08-02
+- Added **Node Settings** menu with options to start or stop hosting a
+  blockchain node.
+- Starting a node creates a `NetworkManager` in host mode and broadcasts an
+  `announce` message so other nodes discover it.
+- Stopping closes the socket to disable hosting and return to client mode.
+
+## 2025-08-03
+- Added ping response handling in `NetworkManager` and a helper to measure
+  latency to other nodes.
+- Clients now choose the best host by pinging all known nodes at startup.
+ - Documented the new behavior in the networking plan and goals.
+
+## 2025-08-04
+- Nodes now act as DNS-style routers. Game hosts send a `register` packet so
+  routers store their address. Clients send `find` to receive the list of
+  available matches. Added helpers in `NetworkManager` and updated plans and
+  goals accordingly.
+
+## 2025-08-05
+- Router nodes broadcast `games_update` packets when their host list changes.
+  This keeps every node's list of joinable matches synchronized.
+
+## 2025-08-06
+- Router nodes now track active clients. When a player registers with a node
+  it adds their address and broadcasts `clients_update` packets so other nodes
+  learn about new peers.
+
+## 2025-08-07
+- Introduced `StateSync` helper and integrated it with `NetworkManager` so state
+  packets only contain changed fields. Each update includes a sequence number to
+  detect lost packets and reduce latency.
+
+## File Overview
+
+This section lists each source file and explains how the modules depend on one
+another.  Paths are relative to the repository root.
+
+| File | Description |
+| ---- | ----------- |
+| `main.py` | Small launcher that calls `hololive_coliseum.game.main`. |
+| `hololive_coliseum/__init__.py` | Package initializer re-exporting all game classes for easy imports. |
+| `hololive_coliseum/game.py` | Main loop, menu system and overall coordinator. Uses most other modules. |
+| `hololive_coliseum/player.py` | Base character logic and subclasses for each VTuber plus the `Enemy` AI. |
+| `hololive_coliseum/projectile.py` | Projectile sprites including exploding and grapple variants. |
+| `hololive_coliseum/melee_attack.py` | Short-lived melee hitbox sprite. |
+| `hololive_coliseum/gravity_zone.py` | Sprite representing low-gravity areas. |
+| `hololive_coliseum/hazards.py` | Contains `SpikeTrap` and `IceZone` terrain hazards. |
+| `hololive_coliseum/powerup.py` | Simple pickup items that heal or restore mana. |
+| `hololive_coliseum/physics.py` | Utility functions for acceleration, friction and gravity. |
+| `hololive_coliseum/network.py` | UDP networking helper used for online multiplayer. |
+| `hololive_coliseum/node_registry.py` | Stores and updates known network node addresses. |
+| `hololive_coliseum/save_manager.py` | Reads/writes `SavedGames/settings.json`. |
+| `tests/` | Unit tests verifying gameplay mechanics and utilities. |
+| `docs/` | Development plans and this notes file. |
+| `Images/` | Placeholder art referenced by the menus. |
+| `sounds/` | Placeholder directory kept empty with `.gitkeep`. |
+
+- Added blockchain module to record multiplayer wins and wagers.
+
+## 2025-08-08
+- Removed stray merge conflict comments left from earlier revisions.
+- Updated `.gitignore` to exclude temporary `test_nodes` directories created by
+  the test suite.
+## 2025-08-09
+ - Clarified zero-vector projectile behavior and extended corresponding test.
+## 2025-08-10
+- Added HMAC signing to all network packets for basic security.
+- Networking plan and goals updated with authentication details.
+## 2025-08-11
+- Implemented reliable packet mode in `NetworkManager` that resends important
+  messages until an `ack` is received.
+- Updated docs and goals with the new networking feature.
+
+## 2025-08-12
+- Reliable packets now have an integer importance level controlling resend rate
+  and attempts.
+- Added `refresh_nodes` and `prune_nodes` to drop unreachable peers.
+- Blockchain module can verify and merge chains from other nodes.
+
+
+## 2025-08-13
+- Added holographic lithography compression for all network packets.
+- NetworkManager now compresses outgoing messages and decompresses on receipt.
+
+## 2025-08-14
+- Added SHA256 verification and optional XOR encryption to the holographic
+  compression module.
+- NetworkManager passes an `encrypt_key` to transparently secure packets.
+
+## 2025-08-15
+- Introduced account registry storing public keys and access levels.
+- Added encrypted messaging blocks to the blockchain. Messages use a mixed key
+  so moderators can decrypt them if needed.
+
+## 2025-08-16
+- Split `blockchain.py` by moving account management into `accounts.py`.
+- Extracted menu rendering helpers into `menus.py` so `game.py` is smaller.
+
+## 2025-08-17
+- Added `delete_account` helper to remove users from the account registry.
+- Updated goals and development plan to mention account deletion.
+
+## 2025-08-18
+- Blockchain `add_game` now validates that all listed players exist in
+  `accounts.json` before recording a block. Updated tests accordingly.
+
+## 2025-08-19
+- Added `get_balance` helper to query player currency totals.
+- `wipe_saves` now removes directories for a clean slate.
+
+## 2025-08-20
+- Tweaked physics constants for smoother motion and introduced a dodge move bound to Left Ctrl.
+- Enemy AI now checks nearby projectiles and may dodge them on harder difficulties.
+
+## 2025-08-21
+- Added Calliope's returning scythe and Kiara's explosive dive.
+- Implemented boomerang and explosion projectiles to support these abilities.
+
+## 2025-08-22
+- Introduced `FreezingProjectile` and `FlockProjectile` subclasses for Fubuki and Mumei.
+- Updated their special attacks to use these classes and added tests.
+
+## 2025-08-23
+- Added HealingZone sprite and updated Fauna's special to create a healing field.
+- Updated docs and tests accordingly.
+
+## 2025-08-24
+- Implemented IRyS crystal shield that blocks enemy projectiles.
+- Updated collision handling and documentation.
+- Added unit test covering the shield ability.
+
+## 2025-08-25
+- Added PiercingProjectile and Sakura Miko's beam special that passes through enemies.
+- Updated character plans, goals and documentation.
+
+## 2025-08-26
+- Introduced eight new placeholder characters to reach twenty total.
+- Character select menu now displays a 5x4 grid of icons so each character has a dedicated box.
+- Updated images list and character plans accordingly.
+
+## 2025-08-27
+- Added grid layout to the map selection screen and "Back" options on most menus.
+- Implemented a simple lobby screen showing joined players before selecting a map.
+- Updated tests and documentation.
+
+## 2025-08-28
+- Added Accounts submenu under Settings with Register/Delete options.
+- `Game.execute_account_option` handles account actions and tests can invoke it.
+- Documentation and goals updated to mark account management implemented.
+
+## 2025-08-29
+- Added a high-gravity zone to levels so jumps are shorter in that area.
+- Updated development plan and goals to mention the new zone.
+- Added tests ensuring both gravity zones load correctly.
+
+## 2025-08-30
+- Polished all menus with a teal border for better readability.
+- Added a pause menu triggered with **Esc** containing Resume and Main Menu options.
+- Documented the new feature and updated goals accordingly.
+
+## 2025-08-31
+- Added a Game Over screen that appears when the player loses all lives.
+- The screen shows the time survived and returns to the main menu.
+
+## 2025-09-01
+- Game Over screen now also displays the best time across runs.
+- Best time persists in settings and updates when a new record is reached.
+
+## 2025-09-02
+- Enemies are removed when their health reaches zero and the player gains a
+  score point.
+- The current score is shown during gameplay and on the Game Over screen.
+
+## 2025-09-03
+- Added victory condition when all enemies are defeated or the timer reaches the
+  limit.
+- A new Victory screen displays the final time, best time and score before
+  returning to the main menu.
+
+## 2025-09-04
+- Game Over and Victory screens now wait three seconds before showing options.
+- Added **Play Again** to return to character selection or **Main Menu** to quit
+  the run.
+
+## 2025-09-05
+- Main menu offers **How to Play** and **Credits** entries with simple screens.
+
+## 2025-09-06
+- Tracked a high score across runs and displayed it on Game Over and Victory screens.
+- Settings now save `best_score` alongside the best time.
+
+## 2025-09-07
+- Added a **Records** screen on the main menu showing the best time and high score.
+- Planned to sync these records across nodes via the blockchain in future updates.
+
+## 2025-09-08
+- Simplified level setup with a character mapping table.
+- Menu rendering now looks up draw functions from a dictionary so the game loop
+  has fewer conditionals.
+- The Settings menu includes **Show FPS** and **Reset Records** options.
+
+## 2025-09-09
+- Records now sync across nodes. When one player achieves a new best time or
+  score, their node broadcasts the update and peers merge it into their own
+  settings.
+
+## 2025-09-10
+- Added a **Latency Helper** toggle in the Node Settings menu.
+- NetworkManager can now forward packets through relay nodes so players with
+  better connections can help reduce latency for others.
+
+## 2025-09-11
+- Added a new **LavaZone** hazard dealing damage over time.
+- Updated level setup to include a lava pit and adjusted collision handling.
+
+## 2025-09-12
+- Implemented a double jump mechanic so players can jump twice before landing.
+
+## 2025-09-13
+- Added Tokino Sora to the roster with an area-of-effect melody special.
+
+## 2025-09-14
+- Introduced `SkillManager` to centralize ability cooldowns. Gura and other characters register their specials with the manager.
+
+## 2025-09-15
+- Added basic `HealthManager`, `ManaManager` and `EquipmentManager` classes to begin modularizing player stats.
+- PlayerCharacter now uses these managers internally.
+
+## 2025-09-16
+- Implemented `AIManager` to coordinate enemy actions.
+- Added `NPCManager` to keep enemy and ally groups organized.
+- Added `AllyManager` for future friendly NPC support.
+
+## 2025-09-17
+- Added MenuManager and GameStateManager modules for organizing menus and state transitions. Game now uses `_set_state` to update them.
+
+## 2025-09-18
+- Introduced `InventoryManager` to track collected items.
+- Added `KeybindManager` so input bindings are stored separately from the `Game` class.
+## 2025-09-19
+- Added StatsManager for base attributes and ExperienceManager for level progression.
+
+## 2025-09-20
+- Created additional management modules including CombatManager, DamageManager,
+  ThreatManager and LootManager.
+- Added BuffManager plus appearance, animation and name managers.
+- Implemented simple session, sync, instance and patch managers for future
+  services.
+## 2025-09-21
+- Added security and UI-related management modules including AuthManager, CheatDetectionManager, BanManager, DataProtectionManager and LoggingManager.
+- Implemented UIManager, NotificationManager, InputManager and AccessibilityManager for front-end features.
+- Created ChatManager, VoiceChatManager and EmoteManager for communication.
+- Added SoundManager and EffectManager placeholders for audio/visual effects.
+## 2025-09-22
+- Introduced ScriptManager, LocalizationManager and ResourceManager for scripting, translation and asset caching.
+- Added server management modules: ClusterManager, MatchmakingManager, LoadBalancerManager and MigrationManager.
+- Implemented BillingManager, AdManager, APIManager and SupportManager for external service integration.
+
+## 2025-09-23
+- Added color-coded anchor metadata to holographic compression so packets
+  include black `(0,0,0)`, red `(1,0,0)`, cyan `(1,0,1)` and white `(1,1,1)`
+  points describing the pointcloud bounds.
+## 2025-09-24
+- Created CraftingManager, ProfessionManager, TradeManager and EconomyManager
+  to handle crafting, professions, trading and pricing.
+## 2025-09-25
+- Added CurrencyManager, TitleManager, ReputationManager, FriendManager,
+  GuildManager and MailManager to flesh out social systems.
+## 2025-09-26
+- Introduced MapManager, EnvironmentManager, SpawnManager, EventManager and DungeonManager for world logic.
+- Added HousingManager along with MountManager, PetManager and CompanionManager for player assets.
+## 2025-09-27
+- Expanded `ChatManager` with open/close state and capped history to display an
+  in-game chat box. Updated tests and documentation.
+## 2025-09-28
+- Integrated the `ChatManager` with `Game` so players can toggle a chat box with
+  Enter during matches. Text input is captured and sent through the manager.
+  Added a new test verifying chat messages send correctly.

--- a/docs/DEV_PLAN.md
+++ b/docs/DEV_PLAN.md
@@ -1,0 +1,178 @@
+# Hololive Coliseum Development Plan
+
+## Project Overview
+Hololive Coliseum is a platform fighting game inspired by Super Smash Brothers, featuring popular Hololive VTubers as playable characters. The game will support single-player and multiplayer modes with both keyboard/mouse and console controller input.
+
+Additional networking concepts are described in `DEV_PLAN_NETWORK.md`.
+
+## Goals
+- Create a playable prototype with advanced features.
+- Implement unique skills for each VTuber character.
+- Develop multiple maps with special gravity zones affecting physics and projectiles.
+- Support local and online multiplayer modes.
+- Provide basic AI opponents for single-player mode.
+
+## Key Features
+1. **Playable Characters**
+   - Unique movesets and special attacks for each Hololive member.
+   - Animations for walking, jumping, attacking, and using special skills.
+   - Double jump mechanic for increased mobility.
+
+2. **Maps**
+   - Different stages with interactive elements.
+   - Gravity modifiers (+/- gravity zones) altering character jump height and projectile paths.
+
+3. **Input Support**
+   - Keyboard + mouse control scheme.
+   - Console controller support (e.g., Xbox, PlayStation, generic USB controllers).
+
+4. **Multiplayer**
+   - Local multiplayer with up to four players.
+   - Networked multiplayer using rollback netcode if feasible.
+
+## Development Steps
+1. **Engine Selection**
+   - For the initial prototype, we use Pygame to quickly iterate on mechanics.
+
+2. **Project Setup**
+   - Initialize repository with engine project files.
+   - Add placeholder assets from `README.md` asset list.
+
+3. **Core Gameplay**
+   - Character controller for movement and jumping.
+   - Basic attacks and hit detection.
+   - Gravity zone logic.
+   - Health and mana resource system with UI bars.
+
+4. **Character Abilities**
+   - Implement unique abilities for each VTuber.
+   - Balance and test.
+
+5. **Multiplayer Implementation**
+   - Add local multiplayer.
+   - Integrate networked multiplayer.
+   - Allow players to join on the character screen and add AI opponents.
+
+6. **Polish and Content**
+   - Improved animations and sound effects.
+   - Additional stages and items.
+
+## Milestones
+1. Prototype with one character and one stage.
+2. Demo with multiple characters and local multiplayer.
+3. Online multiplayer beta.
+4. Version 1.0 release with polished visuals and gameplay.
+
+## Next Steps
+- Continue refining player abilities and additional characters.
+- Add Ouro Kronii with a time-freeze parry. *(Implemented)*
+- Add IRyS with a crystal shield. *(Implemented)*
+- Add Hakos Baelz with a chaos effect. *(Implemented)*
+- Add Sakura Miko with a piercing beam special. *(Implemented)*
+- Polish melee attack, blocking, and parry mechanics.
+- Add a double jump so players can reach higher platforms. *(Implemented)*
+ - Expand maps and experiment with more gravity zones. *(High-gravity zone implemented)*
+ - Introduce spike traps, ice zones and lava pits and teach AI to avoid them.
+- Refine existing local multiplayer features.
+- Flesh out menu flow for starting a game, adding chapter selection for story mode and graphical previews for characters and maps.
+- Add grid-based map selection menu with a Back option and lobby screen listing joined players.
+- Populate story mode with twenty chapter icons representing Gura's growth.
+- Prototype networking with a lightweight UDP manager. Extend it with broadcast
+  discovery so clients can find local hosts automatically and add an online vs
+  offline selection to the menus. Introduce a `node_registry` storing known
+  server addresses so user-hosted nodes can discover each other similar to a
+  Hive network. Add a latency check that pings all known nodes and selects the
+  closest one automatically. Extend nodes so they track active hosts and answer
+  `find` requests from clients, effectively acting as DNS routers for the game.
+  Share connected clients across router nodes using `clients_update` packets so
+  the mesh can discover active players in real time.
+  Add a reliable packet mode that resends important messages until an
+  acknowledgement is received. Reliable packets should include an
+  ``importance`` value to adjust retry rate. Provide ``refresh_nodes`` to remove
+  unreachable peers and merge longer valid blockchains from other nodes.
+  Introduce holographic lithography compression so packets are encoded as
+  compact pointclouds split into two base64 strings. Include colored anchor
+  points at `(0,0,0)`, `(1,0,0)`, `(1,0,1)` and `(1,1,1)` so the decoder knows
+  the pointcloud bounds. Verify pointcloud data with a SHA256 digest and
+  optionally XOR encrypt it using an `encrypt_key`.
+- Harden save loading against corrupt files and ensure volume controls work even when the audio mixer is unavailable.
+- Automatically recreate the `SavedGames` folder if it is deleted so settings save reliably.
+- Spawn AI players during matches with simple pursuit logic.
+- Add a difficulty selector in the character menu to scale AI behavior.
+- Expand AI into Easy, Normal and Hard levels that vary reaction time and
+  attack frequency.
+- Introduce a dodge move for players and teach higher level AI to dodge incoming projectiles.
+- Detect collisions between attacks and enemies to apply damage during combat,
+  and make enemies hurt the player on contact.
+- Implement encrypted messaging on the blockchain. Register account keys and
+  use a mixed admin key to audit messages if abuse occurs.
+- Add helper to remove accounts from `accounts.json` via the settings menu. *(Implemented)*
+- Validate players against the account registry before saving a block to the
+  chain.
+- Add `get_balance` helper returning the stored currency for a player.
+- Add a pause menu accessible with Esc during gameplay. *(Implemented)*
+- Show a Game Over screen with time survived when the player loses all lives.
+- Record the best survival time and show it on the Game Over screen.
+- Record the best score and show it on the Game Over and Victory screens.
+- Track a score for defeated enemies and display it during play and on the Game
+  Over screen.
+- Show a Victory screen when every enemy is defeated or the timer expires.
+- Delay the end screen buttons for a few seconds and include a **Play Again**
+  option that returns to character selection.
+- Add **How to Play** and **Credits** screens accessible from the main menu.
+- Provide a **Records** screen showing the best survival time and high score.
+- Sync these records across nodes so every client sees the latest leaderboard. *(Implemented)*
+- Simplify menu drawing with a lookup table for splash and option screens.
+- Add **Show FPS** toggle and **Reset Records** to the settings menu.
+- Provide a **Latency Helper** option so nodes can relay packets for others and
+  reduce their ping.
+
+- Introduce a `SkillManager` so abilities register once and share cooldown logic.
+- Add `HealthManager` and `ManaManager` classes so health and mana logic is modular.
+- Create an `EquipmentManager` framework for future item slots.
+- Refactor enemy updates into an `AIManager`.
+- Track NPCs with a dedicated `NPCManager` and update friendly helpers through an `AllyManager`.
+- Use a `MenuManager` to manage option navigation.
+- Use a `GameStateManager` so state transitions are consistent.
+- Add an `InventoryManager` so items collected during play can be tracked.
+- Add a `QuestManager` to record tasks and progress.
+- Add an `AchievementManager` so milestones persist between sessions.
+- Centralize input bindings with a `KeybindManager` for easier customization.
+- Introduce a `StatsManager` for STR/DEX/INT and temporary buffs.
+- Add an `ExperienceManager` to handle XP gain and leveling.
+- Implement a `CombatManager` to manage turn order and targeting.
+- Add a `DamageManager` for calculations and reductions.
+- Track aggro with a `ThreatManager` so AI focuses the biggest threat.
+- Provide a `LootManager` for randomized drops.
+- Wrap status effects with a `BuffManager` for stacking rules.
+- Store skins and models in an `AppearanceManager`.
+- Control animation state with an `AnimationManager`.
+- Manage display names via a `NameManager`.
+- Maintain login sessions using a `SessionManager`.
+- Exchange time offsets through a `SyncManager`.
+- Create and destroy gameplay instances with an `InstanceManager`.
+- Record client versions in a simple `PatchManager`.
+- Add `AuthManager` and `BanManager` for login and blacklist handling.
+- Detect cheats via `CheatDetectionManager` and log them with `LoggingManager`.
+- Encrypt packets with `DataProtectionManager`.
+- Provide `UIManager`, `NotificationManager` and `InputManager` for front-end organization.
+- Support chats and voice via `ChatManager` and `VoiceChatManager`.
+- Integrate the `ChatManager` into the game loop with an Enter key toggle and message history so players can chat during matches.
+- Play sounds and trigger effects through `SoundManager` and `EffectManager`.
+- Add a `ScriptManager`/`ScriptingEngine` for map events and modding support.
+- Introduce a `LocalizationManager` for multi-language text.
+- Cache assets with a `ResourceManager` for quicker loading.
+- Coordinate servers via a `ClusterManager` and match players with a `MatchmakingManager`.
+- Use a `LoadBalancerManager` to pick the best server and a `MigrationManager` for world transfers.
+- Implement a `BillingManager` for purchases, an `AdManager` for promotions and an `APIManager` for integrations.
+- Provide a `SupportManager` so players can submit tickets.
+- Introduce a `CraftingManager` and `ProfessionManager` for crafting and profession progression.
+- Add a `TradeManager` so players can swap items and an `EconomyManager` for shared prices.
+- Track currency through a `CurrencyManager`.
+- Unlock titles via a `TitleManager` and track faction standing with a `ReputationManager`.
+- Maintain friends lists through a `FriendManager` and guilds via a `GuildManager`.
+- Provide per-user mailboxes with a `MailManager`.
+- Organize maps with a `MapManager` and track weather via an `EnvironmentManager`.
+- Spawn NPCs using a `SpawnManager` and log occurrences with an `EventManager`.
+- Handle dungeons through a `DungeonManager` and player housing via a `HousingManager`.
+- Manage mounts, pets and companions with dedicated managers.

--- a/docs/DEV_PLAN_CHARACTERS.md
+++ b/docs/DEV_PLAN_CHARACTERS.md
@@ -1,0 +1,28 @@
+# Character Abilities Plan
+
+Each Hololive member will gain a unique special ability. Planned concepts:
+
+- **Gawr Gura**: Exploding trident throw.
+- **Watson Amelia**: Time travel dash that slows opponents. *(Implemented)*
+- **Ninomae Ina'nis**: Tentacle grapple pulling enemies closer. *(Implemented)*
+- **Takanashi Kiara**: Fiery winged leap dealing damage on landing. *(Implemented)*
+- **Mori Calliope**: Soul scythe projectile that returns like a boomerang. *(Implemented)*
+- **Ceres Fauna**: Healing area that restores ally health. *(Implemented)*
+- **Ouro Kronii**: Time freeze parry with extended invulnerability. *(Implemented)*
+- **IRyS**: Crystal shield absorbing projectiles. *(Implemented)*
+- **Nanashi Mumei**: Flock summon that disrupts enemy movement using a `FlockProjectile` subclass. *(Implemented)*
+- **Hakos Baelz**: Randomized chaos effect altering gravity or controls. *(Implemented)*
+- **Shirakami Fubuki**: Freezing shard that slows enemies via a `FreezingProjectile` subclass. *(Implemented)*
+- **Sakura Miko**: Piercing beam that passes through enemies via a `PiercingProjectile` subclass. *(Implemented)*
+ - **Minato Aqua**: Water blast exploding on impact. *(Implemented)*
+ - **Usada Pekora**: Carrot bomb that explodes. *(Implemented)*
+ - **Houshou Marine**: Anchor boomerang returning to her. *(Implemented)*
+ - **Hoshimachi Suisei**: Piercing star projectile. *(Implemented)*
+ - **Nakiri Ayame**: Swift dash attack. *(Implemented)*
+ - **Shirogane Noel**: Ground slam explosion. *(Implemented)*
+ - **Shiranui Flare**: Flame burst projectile. *(Implemented)*
+
+ - **Oozora Subaru**: Stunning blast projectile. *(Implemented)*
+- **Tokino Sora**: Uplifting melody that damages foes in an area. *(Implemented)*
+
+These abilities will be implemented as subclasses of the base `PlayerCharacter` class.

--- a/docs/DEV_PLAN_NETWORK.md
+++ b/docs/DEV_PLAN_NETWORK.md
@@ -1,0 +1,70 @@
+# Networking Plan
+
+The prototype uses a simple UDP based system for minimal latency. Discovery works
+through broadcast packets so clients can locate hosts on the local network. To
+expand beyond a single LAN, the `node_registry` module keeps a list of known
+servers in `SavedGames/nodes.json`. Each host registers itself and sends an
+`announce` packet to other nodes. When a node receives an announcement it adds
+the sender to its registry. This creates a lightweight mesh of user-hosted nodes
+without central coordination.
+Clients ping all known nodes at startup and pick the one with the lowest
+round-trip latency to use for online sessions. In addition to discovery,
+nodes maintain a list of registered game hosts. When a player starts a match
+they send a `register` packet to nearby nodes. Other clients can issue `find`
+requests to any node and receive the list of currently available games. This
+DNS-like approach lets user-hosted nodes route players to each other without a
+central server. It also helps clients choose the closest peer when multiple
+hosts are available.
+Router nodes also share their game lists with each other using `games_update`
+packets so the mesh stays synchronized even as matches come and go. They
+likewise synchronize active clients by broadcasting `clients_update` packets
+whenever a player joins or leaves a node. This will make it easier to scale the
+prototype toward a larger MMO-style environment where servers need to know which
+players are online.
+State updates exchanged during gameplay carry a sequence number and only include
+fields that changed since the previous update. The `StateSync` helper computes
+these diffs so messages remain tiny and reduce network overhead.
+
+Each packet now includes an HMAC signature when a shared secret is configured.
+Nodes verify the signature before processing data so malicious or malformed
+packets are discarded. This lightweight authentication helps secure the mesh
+without adding heavy encryption.
+To further reduce bandwidth usage, packets are compressed using a holographic
+lithography technique. Messages are converted to a pointcloud with four anchor
+points marking `(0,0,0)`, `(1,0,0)`, `(1,0,1)` and `(1,1,1)` in black, red,
+cyan and white. The data is split into two base64 strings and recombined on
+receipt. The encoded bytes
+ include a SHA256 digest so the receiver can verify integrity before decoding.
+ If an `encrypt_key` is supplied, the pointcloud bytes are XOR encrypted so
+ data in transit remains private even over unsecured networks.
+Important control packets can also be sent in **reliable** mode. When enabled
+the sender stores a copy and will resend it until an `ack` message confirms the
+receiver got it. Each reliable packet includes an integer *importance* value so
+critical packets are retried more aggressively. Higher importance reduces the
+wait between resends and increases the total number of attempts. This ensures
+registration and blockchain updates are delivered even if a packet is dropped.
+Nodes periodically prune entries from `nodes.json` if they no longer respond to
+a ping so discovery remains accurate over time.
+Players can toggle hosting from the **Node Settings** menu. Starting a node
+spawns a `NetworkManager` in host mode, registers the address, broadcasts an
+`announce` packet and begins sharing new blockchain blocks. Choosing "Stop Node"
+closes the socket and the game falls back to client-only behavior.
+
+Game results are stored in a lightweight blockchain. When an online match
+finishes the winner "mines" a block containing the participant IDs and optional
+bet amount. The block is written to `chain.json` and shared with other nodes via
+the announce system. Player balances in `balances.json` track wagers and can be
+synchronized in the same way.
+Remote chains can be verified and merged so all nodes eventually share the
+longest valid history.
+
+Nodes also broadcast ``records_update`` packets containing their best survival
+time and high score. Peers merge these records so leaderboards stay consistent
+across the mesh.
+Clients can volunteer to act as relay nodes by enabling the *Latency Helper*
+setting. Router nodes maintain a list of these relays and share them with peers.
+Packets may be forwarded through a relay when it offers a faster path between
+two players, keeping latency low even across distant networks.
+
+Future work will experiment with rollback netcode and more efficient state
+synchronization once the gameplay loop stabilizes.

--- a/docs/DEV_PLAN_SAVESYSTEM.md
+++ b/docs/DEV_PLAN_SAVESYSTEM.md
@@ -1,0 +1,6 @@
+# Save System Notes
+
+The game stores configuration data inside the `SavedGames/` directory.
+The `save_manager` module provides helpers for loading and saving settings.
+Future updates will add player progress and unlocks.
+The save manager now recreates the directory automatically if it has been removed.

--- a/docs/DEV_PLAN_SETTINGS.md
+++ b/docs/DEV_PLAN_SETTINGS.md
@@ -1,0 +1,14 @@
+# Settings Menu Development Plan
+
+The settings menu will allow players to customize their experience. Key areas:
+
+- **Key Bindings**: Rebind actions such as jump, shoot, melee, and special attack.
+- Managed through a `KeybindManager` so bindings can be saved and loaded.
+- **Window Size**: Toggle between common resolutions or allow direct input.
+- **Volume Control**: Adjust master volume for sounds and music.
+- **Save Management**: Provide a button to wipe all files inside `SavedGames/`.
+- **Account Management**: Register or delete the current user account.
+- **Persistence**: Changes persist across sessions via `settings.json`.
+
+Current prototype implements these features with a dedicated key-binding menu
+and volume adjustments using the arrow keys.

--- a/docs/DEV_PLAN_STORY.md
+++ b/docs/DEV_PLAN_STORY.md
@@ -1,0 +1,29 @@
+# Story Mode Plan
+
+The single-player campaign follows Gura's growth as an idol and fighter. Each chapter represents a new year in her journey and unlocks a new map.
+
+## Chapters
+
+1. Chapter 1 – Getting Started
+2. Chapter 2 – First Fans
+3. Chapter 3 – Training Begins
+4. Chapter 4 – Rival Appears
+5. Chapter 5 – First Stage Show
+6. Chapter 6 – Touring Local Clubs
+7. Chapter 7 – Growing Confidence
+8. Chapter 8 – Big City Debut
+9. Chapter 9 – Facing Doubt
+10. Chapter 10 – Breakthrough
+11. Chapter 11 – Worldwide Tour
+12. Chapter 12 – Unexpected Setback
+13. Chapter 13 – Overcoming Fear
+14. Chapter 14 – Uniting Friends
+15. Chapter 15 – Rising Fame
+16. Chapter 16 – Legendary Mentor
+17. Chapter 17 – Struggles of Stardom
+18. Chapter 18 – Preparing for the Coliseum
+19. Chapter 19 – The Final Showdown
+20. Chapter 20 – Idol Champion
+
+Each chapter is selected from the menu via a small map icon. The icons are placeholder images (`chapter1.png` … `chapter20.png`) that can be replaced later with real artwork.
+

--- a/docs/GOALS.md
+++ b/docs/GOALS.md
@@ -1,0 +1,269 @@
+# Project Goals and Architecture Overview
+
+This document collects the current goals and explains how each part of the
+prototype works.  It complements `DEV_PLAN.md` and the other development notes.
+
+## High Level Goals
+
+- Build a platform fighter inspired by Super Smash Brothers with Hololive
+  VTubers.
+- Support both single player and multiplayer, locally and online.
+- Provide controller and keyboard/mouse input with configurable bindings.
+- Include special abilities, projectiles, melee attacks, blocking and parry
+  mechanics.
+- Prototype powerups, gravity zones and basic AI opponents.
+
+## Development Plan
+
+The detailed plan lives in `docs/DEV_PLAN.md`.  In short, we are iterating on a
+Pygame prototype first.  Features are added in small steps:
+
+1. Core player movement with acceleration and friction.
+2. Combat options: shooting, melee, blocking, parry and unique specials.
+3. Menus for splash screen, game type selection, character selection and maps.
+4. Settings menu with key/controller bindings, volume and save management.
+5. Local multiplayer and a lightweight UDP networking layer for online play,
+   using a `node_registry` so hosts can discover each other across the internet.
+6. Additional characters and maps with unique mechanics.
+
+## Module Overview
+
+### `hololive_coliseum.game.Game`
+Handles the main Pygame loop. It coordinates player input, spawns
+projectiles and melee attacks, updates gravity zones and powerups and saves
+settings on exit. Menu drawing helpers now live in `menus.py` which is mixed
+into the `Game` class.
+
+Key methods:
+- `run()` — main loop switching between menu states and gameplay.
+- Menu navigation updates internal state to choose characters, maps and
+  multiplayer options.
+
+### `hololive_coliseum.player.PlayerCharacter`
+Base sprite for all characters and enemies.  Features include:
+- Acceleration and friction based movement using `physics` helpers.
+- Jumping, blocking, parry and gravity adjustment.
+- Ability to double jump before landing.
+- Health, mana and life tracking with a `draw_status` helper.
+- `shoot`, `melee_attack` and `special_attack` create offensive sprites.
+
+`GuraPlayer` extends this class to add the trident special attack.  `Enemy`
+subclasses `PlayerCharacter` and contains a tiny AI routine.
+
+### `hololive_coliseum.projectile`
+Defines `Projectile` and `ExplodingProjectile`.  Projectiles move each frame and
+are removed when leaving the screen or when their timer expires.
+
+### `hololive_coliseum.melee_attack`
+Small hitbox sprite used for close range attacks.  It self-destructs after a few
+frames.
+
+### `hololive_coliseum.gravity_zone`
+Provides the `GravityZone` sprite that modifies gravity for any `Player` inside
+its rectangle.  The `Game` loop checks for collisions with these zones and sets
+the player's gravity multiplier accordingly.
+
+### `hololive_coliseum.powerup`
+Simple powerups that restore health or mana when the player collides with them.
+They are spawned periodically by the `Game` loop.
+
+### `hololive_coliseum.hazards`
+Defines `SpikeTrap` and `IceZone` terrain hazards. `Game` adds these to maps and
+enemy AI will attempt to avoid them.
+
+### `hololive_coliseum.physics`
+Contains helper functions for gravity, acceleration and friction.  These are used
+by the `Player` class to keep movement consistent.
+
+### `hololive_coliseum.network`
+A lightweight UDP manager with discovery so clients can locate local hosts.
+Hosts call `poll()` to process incoming data.  Clients call `discover()` to find
+servers.  Both sides use `send_state()` for game data.
+
+### `hololive_coliseum.node_registry`
+Reads and writes `nodes.json` in the save directory, keeping a list of known
+servers. Hosts add themselves to the registry and share their address via
+`announce` packets so a mesh of nodes can be built.
+
+### `hololive_coliseum.menus`
+Provides ``MenuMixin`` with helpers to draw splash and option menus. ``Game``
+inherits from this mixin so the rendering code is kept separate from gameplay.
+
+### `hololive_coliseum.save_manager`
+Loads and saves configuration files in the `SavedGames` directory.  `Game` uses
+it to store window size, volume and input bindings.  The settings menu can also
+invoke `wipe_saves()` to clear this folder.
+
+### `hololive_coliseum.accounts`
+Manages user accounts stored in ``accounts.json``. Functions allow registering
+public keys and access levels so messages on the blockchain can be encrypted for
+each user. Accounts can also be deleted.
+
+## File Dependencies
+
+- `game.py` imports almost all other modules and drives the simulation.
+- `player.py` relies on `physics.py` for movement logic and spawns projectiles,
+  melee attacks and special projectiles from other modules.
+- `network.py` is optional but used when online multiplayer is selected.
+- `save_manager.py` is required by `game.py` to persist settings.
+- Tests under `tests/` import these modules to verify key features.
+
+## Interplay
+
+During gameplay, `Game` calls `player.handle_input()` which uses
+`physics.accelerate` and `physics.apply_friction` to update velocity.  Each frame
+`player.update()` applies gravity via `physics.apply_gravity` and checks for
+parry timing.  When attacks occur, new `Projectile` or `MeleeAttack` sprites are
+added to the `all_sprites` group.  `GravityZone` sprites alter the player's
+gravity multiplier, and `PowerUp` sprites restore health or mana when collected.
+
+Settings are loaded at startup and saved on exit through `save_manager`.  If
+online mode is chosen, `NetworkManager` handles packet exchange for state
+synchronization or discovery of other hosts.
+
+## Short-Term Goals
+
+- Flesh out each VTuber's unique abilities (see `DEV_PLAN_CHARACTERS.md`).
+*Watson Amelia implemented.*
+ *Ninomae Ina'nis implemented.*
+ *Shirakami Fubuki implemented.*
+ *Sakura Miko implemented.*
+*Ceres Fauna implemented.*
+*Nanashi Mumei implemented.*
+*Ouro Kronii implemented.*
+*IRyS implemented.*
+   *Hakos Baelz implemented.*
+   *Tokino Sora implemented.*
+   *Minato Aqua implemented.*
+   *Usada Pekora implemented.*
+   *Houshou Marine implemented.*
+   *Hoshimachi Suisei implemented.*
+   *Nakiri Ayame implemented.*
+   *Shirogane Noel implemented.*
+   *Shiranui Flare implemented.*
+   *Oozora Subaru implemented.*
+  - Roster expanded to **21** playable characters with unique specials.
+ - Expand map mechanics with gravity zones, spike traps, ice patches and lava pits. *(High-gravity zone added)*
+- Improve enemy AI to navigate around hazards intelligently.
+- Add AI-controlled opponents that use the shared `PlayerCharacter` base class.
+- Provide a difficulty selector so AI behavior can scale from Easy to Hard.
+- Implement three AI levels with different reaction times and aggression.
+- Add a dodge action for players and let advanced AI attempt dodges when threatened.
+- Support double jumps for greater mobility. *(Implemented)*
+- Implement combat collisions so projectiles and melee attacks damage
+  enemies, and enemies now harm the player on contact.
+- Polish menus with clearer prompts and optional controller hints. *(Improved with teal borders)*
+- Draw menus via a lookup table instead of long chains of conditionals.
+- Add an in-game pause menu triggered with Esc.
+- Display a Game Over screen when the player runs out of lives.
+- Track the best survival time and show it on the Game Over screen.
+- Track the highest score and show it on Game Over and Victory screens.
+- Keep a running score of defeated enemies and display it during gameplay and on
+  the Game Over screen.
+- Show a Victory screen when the timer expires or all enemies are defeated.
+- End screens should pause for a moment before showing **Play Again** and
+  **Main Menu** buttons; Play Again returns to character selection.
+- Provide **How to Play** instructions and a **Credits** screen in the main menu.
+- Include a **Records** menu showing your best time and high score.
+- Sync records across nodes so everyone sees the latest leaderboard.
+- Add **Show FPS** and **Reset Records** options to the settings menu.
+- Add grid-based map selection and a lobby screen listing joined players.
+- Continue adding tests for new mechanics as they appear.
+- Cover edge cases like zero-length projectile shots to prevent crashes.
+- Design the "Growing Up" story mode with 20 chapter icons that load each level.
+- Record multiplayer results in a lightweight blockchain so wins submit a block
+  shared with other players. Include search tools and a simple currency for
+  betting on matches.
+- Allow players to start or stop acting as a blockchain node from the settings
+  menu to help grow a decentralized network.
+- Offer a **Latency Helper** toggle so willing players can act as relay nodes and
+  route traffic for others when they have a faster connection.
+- Provide account management features including deleting accounts when needed. *(Implemented)*
+- Validate that all players recorded on the blockchain have registered accounts.
+- Provide `get_balance` to read each player's currency amount from `balances.json`.
+- Ping known nodes at startup and connect to the one with the lowest latency.
+- Nodes act as game routers: hosts register with them and clients query for
+  available matches so players can find each other across the mesh.
+- Router nodes exchange game lists via `games_update` packets and also
+  synchronize active clients with `clients_update` so the mesh knows who is
+  online.
+- State updates use the `StateSync` delta system with sequence numbers for
+  efficient packet sizes and minimal latency.
+- Packets include an HMAC signature when a shared secret is set so nodes can
+  discard tampered data.
+- Compress network traffic using a holographic lithography approach that
+  converts each packet into a compact pointcloud represented by two base64
+  strings. Anchor points at `(0,0,0)` (black), `(1,0,0)` (red), `(1,0,1)` (cyan)
+  and `(1,1,1)` (white) describe the bounds so peers can reconstruct packets.
+- Verify the pointcloud bytes with a SHA256 digest and optionally XOR encrypt
+  them while in transit.
+- Important control packets support a **reliable** mode that resends them until
+  acknowledged so critical data like game registration is not lost.
+- Reliable packets accept an integer importance so crucial updates retry faster
+  and more often.
+- Nodes periodically drop unreachable peers from the registry to keep the mesh
+  healthy.
+- Blockchain data can be verified and longer valid chains replace stale copies.
+
+## Long-Term Goals
+
+- Improve network latency handling and implement rollback if possible.
+- Add proper sprites and sound effects once the gameplay loop is solid.
+- Introduce a full story mode with chapters and cutscenes.
+- Package the game for multiple platforms with configurable installers.
+- Handle corrupt save files gracefully and keep UI responsive even without audio support.
+- Ensure the save directory is recreated automatically if missing.
+- Support encrypted player messaging with public and admin keys so abusive
+  chats can be audited while regular messages remain private.
+
+- Centralize special ability cooldowns through a `SkillManager`.
+- Add dedicated `HealthManager` and `ManaManager` classes for resource tracking.
+- Introduce an `EquipmentManager` so players can equip items in various slots.
+- Manage all enemies through an `AIManager` so decision logic stays organized.
+- Provide an `NPCManager` for grouping enemies and potential allies.
+- Add an `AllyManager` to update friendly NPC behavior.
+- Track menu navigation with a `MenuManager` so option handling is reusable.
+- Track the current game state in a `GameStateManager` for cleaner transitions.
+- Manage player inventory with an `InventoryManager`.
+- Track quests with a `QuestManager` so objectives can be completed.
+- Record achievements with an `AchievementManager`.
+- Store key mappings in a `KeybindManager` so rebinding works consistently.
+- Provide a `StatsManager` for core attributes with modifiers.
+- Implement an `ExperienceManager` for XP and leveling logic.
+- Introduce a `CombatManager` for turn order.
+- Add a `DamageManager` to handle reductions.
+- Keep aggro tables in a `ThreatManager`.
+- Generate item drops with a `LootManager`.
+- Coordinate buffs through a `BuffManager`.
+- Store character skins in an `AppearanceManager`.
+- Track animations via an `AnimationManager`.
+- Support renames with a `NameManager`.
+- Manage login tokens using a `SessionManager`.
+- Keep clocks synchronized through a `SyncManager`.
+- Spin up separate sessions using an `InstanceManager`.
+- Track game versions with a `PatchManager`.
+- Enforce logins and bans with `AuthManager` and `BanManager`.
+- Detect cheating through `CheatDetectionManager` and record events via `LoggingManager`.
+- Secure data using `DataProtectionManager`.
+- Organize UI with `UIManager` and show alerts via `NotificationManager`.
+- Centralize controls with `InputManager` and accessibility settings with `AccessibilityManager`.
+- Provide text and voice communication using `ChatManager` and `VoiceChatManager`.
+- The chat manager is integrated with gameplay: pressing Enter toggles the chat box and messages are stored in a limited history.
+- Manage audio and visual effects through `SoundManager` and `EffectManager`.
+- Load and execute scripts with a `ScriptManager`.
+- Provide translations through a `LocalizationManager`.
+- Cache assets using a `ResourceManager`.
+- Manage cross-server groups via a `ClusterManager` and `MatchmakingManager`.
+- Balance server load with a `LoadBalancerManager` and support migrations through a `MigrationManager`.
+- Track purchases using a `BillingManager` and display ads with an `AdManager`.
+- Integrate third-party services through an `APIManager` and handle support tickets via `SupportManager`.
+- Handle crafting via a `CraftingManager` and track professions through a `ProfessionManager`.
+- Manage player trades with a `TradeManager` and global prices via an `EconomyManager`.
+- Track gold and other money with a `CurrencyManager`.
+- Unlock titles using a `TitleManager` and adjust faction standing via a `ReputationManager`.
+- Maintain friends and guilds through `FriendManager` and `GuildManager`.
+- Provide mailboxes through a `MailManager`.
+- Organize world data with a `MapManager` and `EnvironmentManager`.
+- Control spawns via a `SpawnManager` and log events through an `EventManager`.
+- Handle dungeon lockouts using a `DungeonManager` and store housing via a `HousingManager`.
+- Track mounts with a `MountManager`, pets with a `PetManager` and companions via a `CompanionManager`.

--- a/hololive_coliseum/__init__.py
+++ b/hololive_coliseum/__init__.py
@@ -1,0 +1,292 @@
+"""Hololive Coliseum game package."""
+
+__all__ = [
+    "Game",
+    "PlayerCharacter",
+    "Player",
+    "GuraPlayer",
+    "WatsonPlayer",
+    "InaPlayer",
+    "KiaraPlayer",
+    "CalliopePlayer",
+    "FaunaPlayer",
+    "KroniiPlayer",
+    "IRySPlayer",
+    "MumeiPlayer",
+    "BaelzPlayer",
+    "FubukiPlayer",
+    "MikoPlayer",
+    "AquaPlayer",
+    "PekoraPlayer",
+    "MarinePlayer",
+    "SuiseiPlayer",
+    "AyamePlayer",
+    "NoelPlayer",
+    "FlarePlayer",
+    "SubaruPlayer",
+    "SoraPlayer",
+    "Enemy",
+    "Projectile",
+    "ExplodingProjectile",
+    "BoomerangProjectile",
+    "ExplosionProjectile",
+    "GrappleProjectile",
+    "FreezingProjectile",
+    "FlockProjectile",
+    "PiercingProjectile",
+    "PowerUp",
+    "SpikeTrap",
+    "IceZone",
+    "LavaZone",
+    "HealingZone",
+    "physics",
+    "GravityZone",
+    "MeleeAttack",
+    "load_settings",
+    "save_settings",
+    "wipe_saves",
+    "merge_records",
+    "NetworkManager",
+    "StateSync",
+    "load_nodes",
+    "save_nodes",
+    "add_node",
+    "prune_nodes",
+    "load_chain",
+    "save_chain",
+    "add_game",
+    "search",
+    "add_contract",
+    "fulfill_contract",
+    "verify_chain",
+    "merge_chain",
+    "load_balances",
+    "save_balances",
+    "load_accounts",
+    "save_accounts",
+    "register_account",
+    "delete_account",
+    "get_account",
+    "add_message",
+    "decrypt_message",
+    "admin_decrypt",
+    "compress_packet",
+    "decompress_packet",
+    "SkillManager",
+    "HealthManager",
+    "ManaManager",
+    "StatsManager",
+    "ExperienceManager",
+    "EquipmentManager",
+    "InventoryManager",
+    "QuestManager",
+    "AchievementManager",
+    "KeybindManager",
+    "AIManager",
+    "NPCManager",
+    "AllyManager",
+    "MenuManager",
+    "GameStateManager",
+    "StatusEffectManager",
+    "FreezeEffect",
+    "SlowEffect",
+    "CombatManager",
+    "DamageManager",
+    "ThreatManager",
+    "LootManager",
+    "BuffManager",
+    "AppearanceManager",
+    "AnimationManager",
+    "NameManager",
+    "SessionManager",
+    "SyncManager",
+    "InstanceManager",
+    "PatchManager",
+    "AuthManager",
+    "CheatDetectionManager",
+    "BanManager",
+    "DataProtectionManager",
+    "LoggingManager",
+    "UIManager",
+    "NotificationManager",
+    "InputManager",
+    "AccessibilityManager",
+    "ChatManager",
+    "VoiceChatManager",
+    "EmoteManager",
+    "SoundManager",
+    "EffectManager",
+    "ScriptManager",
+    "LocalizationManager",
+    "ResourceManager",
+    "ClusterManager",
+    "MatchmakingManager",
+    "LoadBalancerManager",
+    "MigrationManager",
+    "BillingManager",
+    "AdManager",
+    "APIManager",
+    "SupportManager",
+    "CurrencyManager",
+    "TitleManager",
+    "ReputationManager",
+    "FriendManager",
+    "GuildManager",
+    "MailManager",
+    "CraftingManager",
+    "ProfessionManager",
+    "TradeManager",
+    "EconomyManager",
+    "MapManager",
+    "EnvironmentManager",
+    "SpawnManager",
+    "EventManager",
+    "DungeonManager",
+    "HousingManager",
+    "MountManager",
+    "PetManager",
+    "CompanionManager",
+]
+
+from .game import Game
+from .player import (
+    PlayerCharacter,
+    Player,
+    GuraPlayer,
+    WatsonPlayer,
+    InaPlayer,
+    KiaraPlayer,
+    CalliopePlayer,
+    FaunaPlayer,
+    KroniiPlayer,
+    IRySPlayer,
+    MumeiPlayer,
+    BaelzPlayer,
+    FubukiPlayer,
+    MikoPlayer,
+    AquaPlayer,
+    PekoraPlayer,
+    MarinePlayer,
+    SuiseiPlayer,
+    AyamePlayer,
+    NoelPlayer,
+    FlarePlayer,
+    SubaruPlayer,
+    SoraPlayer,
+    Enemy,
+)
+from .projectile import (
+    Projectile,
+    ExplodingProjectile,
+    GrappleProjectile,
+    BoomerangProjectile,
+    ExplosionProjectile,
+    FreezingProjectile,
+    FlockProjectile,
+    PiercingProjectile,
+)
+from .gravity_zone import GravityZone
+from .melee_attack import MeleeAttack
+from .powerup import PowerUp
+from .hazards import SpikeTrap, IceZone, LavaZone
+from .healing_zone import HealingZone
+from . import physics
+from .save_manager import load_settings, save_settings, wipe_saves, merge_records
+from .network import NetworkManager
+from .state_sync import StateSync
+from .node_registry import load_nodes, save_nodes, add_node, prune_nodes
+from .blockchain import (
+    load_chain,
+    save_chain,
+    add_game,
+    search,
+    add_contract,
+    fulfill_contract,
+    load_balances,
+    save_balances,
+    verify_chain,
+    merge_chain,
+    add_message,
+    decrypt_message,
+    admin_decrypt,
+)
+from .accounts import (
+    load_accounts,
+    save_accounts,
+    register_account,
+    delete_account,
+    get_account,
+)
+from .holographic_compression import compress_packet, decompress_packet
+from .status_effects import StatusEffectManager, FreezeEffect, SlowEffect
+from .skill_manager import SkillManager
+from .health_manager import HealthManager
+from .mana_manager import ManaManager
+from .equipment_manager import EquipmentManager
+from .inventory_manager import InventoryManager
+from .quest_manager import QuestManager
+from .achievement_manager import AchievementManager
+from .keybind_manager import KeybindManager
+from .stats_manager import StatsManager
+from .experience_manager import ExperienceManager
+from .ai_manager import AIManager
+from .npc_manager import NPCManager
+from .ally_manager import AllyManager
+from .menu_manager import MenuManager
+from .game_state_manager import GameStateManager
+from .combat_manager import CombatManager
+from .damage_manager import DamageManager
+from .threat_manager import ThreatManager
+from .loot_manager import LootManager
+from .buff_manager import BuffManager
+from .appearance_manager import AppearanceManager
+from .animation_manager import AnimationManager
+from .name_manager import NameManager
+from .session_manager import SessionManager
+from .sync_manager import SyncManager
+from .instance_manager import InstanceManager
+from .patch_manager import PatchManager
+from .auth_manager import AuthManager
+from .cheat_detection_manager import CheatDetectionManager
+from .ban_manager import BanManager
+from .data_protection_manager import DataProtectionManager
+from .logging_manager import LoggingManager
+from .ui_manager import UIManager
+from .notification_manager import NotificationManager
+from .input_manager import InputManager
+from .accessibility_manager import AccessibilityManager
+from .chat_manager import ChatManager
+from .voice_chat_manager import VoiceChatManager
+from .emote_manager import EmoteManager
+from .sound_manager import SoundManager
+from .effect_manager import EffectManager
+from .script_manager import ScriptManager
+from .localization_manager import LocalizationManager
+from .resource_manager import ResourceManager
+from .cluster_manager import ClusterManager
+from .matchmaking_manager import MatchmakingManager
+from .load_balancer_manager import LoadBalancerManager
+from .migration_manager import MigrationManager
+from .billing_manager import BillingManager
+from .ad_manager import AdManager
+from .api_manager import APIManager
+from .support_manager import SupportManager
+from .currency_manager import CurrencyManager
+from .title_manager import TitleManager
+from .reputation_manager import ReputationManager
+from .friend_manager import FriendManager
+from .guild_manager import GuildManager
+from .mail_manager import MailManager
+from .crafting_manager import CraftingManager
+from .profession_manager import ProfessionManager
+from .trade_manager import TradeManager
+from .economy_manager import EconomyManager
+from .map_manager import MapManager
+from .environment_manager import EnvironmentManager
+from .spawn_manager import SpawnManager
+from .event_manager import EventManager
+from .dungeon_manager import DungeonManager
+from .housing_manager import HousingManager
+from .mount_manager import MountManager
+from .pet_manager import PetManager
+from .companion_manager import CompanionManager

--- a/hololive_coliseum/accessibility_manager.py
+++ b/hololive_coliseum/accessibility_manager.py
@@ -1,0 +1,9 @@
+class AccessibilityManager:
+    """Store toggles for accessibility features."""
+
+    def __init__(self):
+        self.options = {"colorblind": False, "font_scale": 1.0}
+
+    def toggle(self, name: str) -> None:
+        if name in self.options and isinstance(self.options[name], bool):
+            self.options[name] = not self.options[name]

--- a/hololive_coliseum/accounts.py
+++ b/hololive_coliseum/accounts.py
@@ -1,0 +1,54 @@
+"""User account registry storing public keys and access levels."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict
+
+SAVE_DIR = os.path.join(os.path.dirname(__file__), '..', 'SavedGames')
+os.makedirs(SAVE_DIR, exist_ok=True)
+ACCOUNTS_FILE = os.path.join(SAVE_DIR, 'accounts.json')
+
+
+def _load_json(path: str, default: Any) -> Any:
+    if os.path.exists(path):
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return default
+    return default
+
+
+def _save_json(path: str, data: Any) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f)
+
+
+def load_accounts() -> Dict[str, Dict[str, str]]:
+    """Return saved account data mapping user IDs to level and public key."""
+    return _load_json(ACCOUNTS_FILE, {})
+
+
+def save_accounts(data: Dict[str, Dict[str, str]]) -> None:
+    _save_json(ACCOUNTS_FILE, data)
+
+
+def register_account(user_id: str, level: str, public_key_pem: str) -> None:
+    accounts = load_accounts()
+    accounts[user_id] = {"level": level, "public_key": public_key_pem}
+    save_accounts(accounts)
+
+
+def delete_account(user_id: str) -> None:
+    """Remove ``user_id`` from the registry if present."""
+    accounts = load_accounts()
+    if user_id in accounts:
+        del accounts[user_id]
+        save_accounts(accounts)
+
+
+def get_account(user_id: str) -> Dict[str, str] | None:
+    return load_accounts().get(user_id)

--- a/hololive_coliseum/achievement_manager.py
+++ b/hololive_coliseum/achievement_manager.py
@@ -1,0 +1,17 @@
+class AchievementManager:
+    """Record unlocked achievements."""
+
+    def __init__(self) -> None:
+        self.unlocked: set[str] = set()
+
+    def unlock(self, name: str) -> None:
+        self.unlocked.add(name)
+
+    def is_unlocked(self, name: str) -> bool:
+        return name in self.unlocked
+
+    def to_dict(self) -> dict:
+        return {"achievements": list(self.unlocked)}
+
+    def load_from_dict(self, data: dict) -> None:
+        self.unlocked = set(data.get("achievements", []))

--- a/hololive_coliseum/ad_manager.py
+++ b/hololive_coliseum/ad_manager.py
@@ -1,0 +1,11 @@
+class AdManager:
+    """Manage in-game advertisements and promotions."""
+
+    def __init__(self) -> None:
+        self.ads: list[str] = []
+
+    def add_ad(self, text: str) -> None:
+        self.ads.append(text)
+
+    def current_ads(self) -> list[str]:
+        return self.ads

--- a/hololive_coliseum/ai_manager.py
+++ b/hololive_coliseum/ai_manager.py
@@ -1,0 +1,19 @@
+class AIManager:
+    """Coordinate AI updates for enemy sprites."""
+
+    def __init__(self, enemies) -> None:
+        self.enemies = enemies
+
+    def update(self, player, now, hazards=None, projectiles=None):
+        """Run AI logic for all enemies and return actions."""
+        hazards = hazards or []
+        projectiles = projectiles or []
+        new_projectiles = []
+        new_melees = []
+        for enemy in list(self.enemies):
+            proj, melee = enemy.handle_ai(player, now, hazards, projectiles)
+            if proj:
+                new_projectiles.append((enemy, proj))
+            if melee:
+                new_melees.append((enemy, melee))
+        return new_projectiles, new_melees

--- a/hololive_coliseum/ally_manager.py
+++ b/hololive_coliseum/ally_manager.py
@@ -1,0 +1,14 @@
+class AllyManager:
+    """Simple manager for friendly NPCs that follow the player."""
+
+    def __init__(self, allies) -> None:
+        self.allies = allies
+
+    def update(self, player, ground_y: int, now: int) -> None:
+        for ally in list(self.allies):
+            if hasattr(ally, "handle_ai"):
+                ally.handle_ai(player, now)
+            else:
+                direction = 1 if player.rect.centerx > ally.rect.centerx else -1
+                ally.velocity.x = direction
+            ally.update(ground_y, now)

--- a/hololive_coliseum/animation_manager.py
+++ b/hololive_coliseum/animation_manager.py
@@ -1,0 +1,14 @@
+class AnimationManager:
+    """Track simple animation states and frames."""
+
+    def __init__(self) -> None:
+        self.state = "idle"
+        self.frame = 0
+
+    def set_state(self, state: str) -> None:
+        if state != self.state:
+            self.state = state
+            self.frame = 0
+
+    def update(self) -> None:
+        self.frame += 1

--- a/hololive_coliseum/api_manager.py
+++ b/hololive_coliseum/api_manager.py
@@ -1,0 +1,11 @@
+class APIManager:
+    """Store webhook endpoints for third-party integrations."""
+
+    def __init__(self) -> None:
+        self.endpoints: dict[str, str] = {}
+
+    def add_endpoint(self, name: str, url: str) -> None:
+        self.endpoints[name] = url
+
+    def get(self, name: str) -> str | None:
+        return self.endpoints.get(name)

--- a/hololive_coliseum/appearance_manager.py
+++ b/hololive_coliseum/appearance_manager.py
@@ -1,0 +1,11 @@
+class AppearanceManager:
+    """Store visual appearance selections for entities."""
+
+    def __init__(self) -> None:
+        self.skins: dict = {}
+
+    def set_skin(self, entity, skin: str) -> None:
+        self.skins[entity] = skin
+
+    def get_skin(self, entity) -> str | None:
+        return self.skins.get(entity)

--- a/hololive_coliseum/auth_manager.py
+++ b/hololive_coliseum/auth_manager.py
@@ -1,0 +1,19 @@
+class AuthManager:
+    """Handle account credentials and simple session tokens."""
+
+    def __init__(self):
+        self.users = {}
+        self.tokens = {}
+
+    def register(self, username: str, password: str) -> None:
+        self.users[username] = password
+
+    def login(self, username: str, password: str):
+        if self.users.get(username) == password:
+            token = f"{username}-token"
+            self.tokens[token] = username
+            return token
+        return None
+
+    def verify(self, token: str) -> bool:
+        return token in self.tokens

--- a/hololive_coliseum/ban_manager.py
+++ b/hololive_coliseum/ban_manager.py
@@ -1,0 +1,14 @@
+class BanManager:
+    """Maintain a list of banned users."""
+
+    def __init__(self):
+        self.banned = set()
+
+    def ban(self, user: str) -> None:
+        self.banned.add(user)
+
+    def unban(self, user: str) -> None:
+        self.banned.discard(user)
+
+    def is_banned(self, user: str) -> bool:
+        return user in self.banned

--- a/hololive_coliseum/billing_manager.py
+++ b/hololive_coliseum/billing_manager.py
@@ -1,0 +1,11 @@
+class BillingManager:
+    """Track player purchases and subscriptions."""
+
+    def __init__(self) -> None:
+        self.records: dict[str, list[str]] = {}
+
+    def add_purchase(self, user_id: str, item: str) -> None:
+        self.records.setdefault(user_id, []).append(item)
+
+    def get_purchases(self, user_id: str) -> list[str]:
+        return self.records.get(user_id, [])

--- a/hololive_coliseum/blockchain.py
+++ b/hololive_coliseum/blockchain.py
@@ -1,0 +1,223 @@
+import json
+import os
+import time
+import uuid
+import hashlib
+import base64
+from typing import Any, Dict, List
+
+from cryptography.fernet import Fernet
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+
+from .accounts import get_account
+
+# Path to SavedGames directory used by save_manager
+SAVE_DIR = os.path.join(os.path.dirname(__file__), '..', 'SavedGames')
+os.makedirs(SAVE_DIR, exist_ok=True)
+CHAIN_FILE = os.path.join(SAVE_DIR, 'chain.json')
+BALANCE_FILE = os.path.join(SAVE_DIR, 'balances.json')
+CONTRACT_FILE = os.path.join(SAVE_DIR, 'contracts.json')
+
+
+def _load_json(path: str, default: Any) -> Any:
+    if os.path.exists(path):
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return default
+    return default
+
+
+def _save_json(path: str, data: Any) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f)
+
+
+def load_chain() -> List[Dict[str, Any]]:
+    """Return the saved blockchain."""
+    return _load_json(CHAIN_FILE, [])
+
+
+def save_chain(chain: List[Dict[str, Any]]) -> None:
+    _save_json(CHAIN_FILE, chain)
+
+
+def load_balances() -> Dict[str, int]:
+    return _load_json(BALANCE_FILE, {})
+
+
+def save_balances(data: Dict[str, int]) -> None:
+    _save_json(BALANCE_FILE, data)
+
+
+def get_balance(user_id: str) -> int:
+    """Return the stored balance for ``user_id`` or ``0`` if missing."""
+    balances = load_balances()
+    return balances.get(user_id, 0)
+
+
+
+
+def _hash_block(data: Dict[str, Any]) -> str:
+    raw = json.dumps(data, sort_keys=True).encode('utf-8')
+    return hashlib.sha256(raw).hexdigest()
+
+
+def add_game(players: List[str], winner: str, bet: int = 0, game_id: str | None = None) -> Dict[str, Any]:
+    """Append a new game result to the blockchain and update balances.
+
+    Each ``player`` must exist in the account registry or a ``ValueError`` is
+    raised.
+    """
+    for p in players:
+        if get_account(p) is None:
+            raise ValueError(f"unknown account: {p}")
+    chain = load_chain()
+    prev_hash = chain[-1]['hash'] if chain else ''
+    if game_id is None:
+        game_id = uuid.uuid4().hex
+    block = {
+        'index': len(chain),
+        'game_id': game_id,
+        'players': players,
+        'winner': winner,
+        'bet': bet,
+        'timestamp': int(time.time()),
+        'prev_hash': prev_hash,
+    }
+    block['hash'] = _hash_block(block)
+    chain.append(block)
+    save_chain(chain)
+
+    if bet:
+        balances = load_balances()
+        for p in players:
+            balances[p] = balances.get(p, 0) - bet
+        balances[winner] = balances.get(winner, 0) + bet * len(players)
+        save_balances(balances)
+    return block
+
+
+def search(game_id: str | None = None, user_id: str | None = None) -> List[Dict[str, Any]]:
+    """Search blocks by game ID and/or user ID."""
+    chain = load_chain()
+    results = chain
+    if game_id is not None:
+        results = [b for b in results if b['game_id'] == game_id]
+    if user_id is not None:
+        results = [b for b in results if user_id in b['players']]
+    return results
+
+
+def add_contract(request_id: str, players: List[str], bet: int) -> None:
+    contracts = _load_json(CONTRACT_FILE, {})
+    contracts[request_id] = {'players': players, 'bet': bet}
+    _save_json(CONTRACT_FILE, contracts)
+
+
+def fulfill_contract(request_id: str, winner: str) -> Dict[str, Any] | None:
+    contracts = _load_json(CONTRACT_FILE, {})
+    contract = contracts.pop(request_id, None)
+    if contract is None:
+        return None
+    _save_json(CONTRACT_FILE, contracts)
+    return add_game(contract['players'], winner, contract['bet'], game_id=request_id)
+
+
+def verify_chain(chain: List[Dict[str, Any]]) -> bool:
+    """Return True if the chain hashes link correctly."""
+    prev_hash = ''
+    for block in chain:
+        expect = _hash_block({k: block[k] for k in block if k != 'hash'})
+        if block.get('prev_hash') != prev_hash or block.get('hash') != expect:
+            return False
+        prev_hash = block['hash']
+    return True
+
+
+def merge_chain(remote: List[Dict[str, Any]]) -> None:
+    """Merge a remote chain with the local one if it is valid and longer."""
+    if not verify_chain(remote):
+        return
+    local = load_chain()
+    if len(remote) > len(local):
+        save_chain(remote)
+
+
+def add_message(
+    sender: str,
+    recipient: str,
+    message: str,
+    admin_public_key_pem: bytes,
+) -> Dict[str, Any]:
+    """Encrypt ``message`` for ``recipient`` and append it as a block.
+
+    The message is encrypted with a random symmetric key. That key is encrypted
+    twice: once with the recipient's public key and once with the admin key so
+    moderators can decrypt abusive messages if necessary.
+    """
+    recipient_info = get_account(recipient)
+    if recipient_info is None:
+        raise ValueError("unknown recipient")
+
+    rec_pub = serialization.load_pem_public_key(
+        recipient_info["public_key"].encode("utf-8")
+    )
+    admin_pub = serialization.load_pem_public_key(admin_public_key_pem)
+
+    sym_key = Fernet.generate_key()
+    cipher = Fernet(sym_key).encrypt(message.encode("utf-8"))
+
+    enc_rec = rec_pub.encrypt(
+        sym_key,
+        padding.OAEP(mgf=padding.MGF1(algorithm=hashes.SHA256()), algorithm=hashes.SHA256(), label=None),
+    )
+    enc_admin = admin_pub.encrypt(
+        sym_key,
+        padding.OAEP(mgf=padding.MGF1(algorithm=hashes.SHA256()), algorithm=hashes.SHA256(), label=None),
+    )
+
+    chain = load_chain()
+    prev_hash = chain[-1]["hash"] if chain else ""
+    block = {
+        "index": len(chain),
+        "type": "message",
+        "sender": sender,
+        "recipient": recipient,
+        "cipher": base64.b64encode(cipher).decode("ascii"),
+        "key_user": base64.b64encode(enc_rec).decode("ascii"),
+        "key_admin": base64.b64encode(enc_admin).decode("ascii"),
+        "timestamp": int(time.time()),
+        "prev_hash": prev_hash,
+    }
+    block["hash"] = _hash_block(block)
+    chain.append(block)
+    save_chain(chain)
+    return block
+
+
+def decrypt_message(block: Dict[str, Any], private_key_pem: bytes) -> str:
+    """Return the plaintext of ``block`` using the recipient's private key."""
+    if block.get("type") != "message":
+        raise ValueError("not a message block")
+    priv = serialization.load_pem_private_key(private_key_pem, password=None)
+    sym_key = priv.decrypt(
+        base64.b64decode(block["key_user"]),
+        padding.OAEP(mgf=padding.MGF1(algorithm=hashes.SHA256()), algorithm=hashes.SHA256(), label=None),
+    )
+    return Fernet(sym_key).decrypt(base64.b64decode(block["cipher"])).decode("utf-8")
+
+
+def admin_decrypt(block: Dict[str, Any], admin_private_key_pem: bytes) -> str:
+    """Decrypt a message block using the admin private key."""
+    if block.get("type") != "message":
+        raise ValueError("not a message block")
+    priv = serialization.load_pem_private_key(admin_private_key_pem, password=None)
+    sym_key = priv.decrypt(
+        base64.b64decode(block["key_admin"]),
+        padding.OAEP(mgf=padding.MGF1(algorithm=hashes.SHA256()), algorithm=hashes.SHA256(), label=None),
+    )
+    return Fernet(sym_key).decrypt(base64.b64decode(block["cipher"])).decode("utf-8")

--- a/hololive_coliseum/buff_manager.py
+++ b/hololive_coliseum/buff_manager.py
@@ -1,0 +1,13 @@
+from .status_effects import StatusEffectManager
+
+class BuffManager:
+    """Wrapper managing buff and debuff status effects."""
+
+    def __init__(self) -> None:
+        self.manager = StatusEffectManager()
+
+    def add_buff(self, target, effect) -> None:
+        self.manager.add_effect(target, effect)
+
+    def update(self, now: int | None = None) -> None:
+        self.manager.update(now)

--- a/hololive_coliseum/chat_manager.py
+++ b/hololive_coliseum/chat_manager.py
@@ -1,0 +1,29 @@
+class ChatManager:
+    """Manage an in-game chat box with message history."""
+
+    def __init__(self, max_messages: int = 50):
+        self.max_messages = max_messages
+        self.messages: list[tuple[str, str]] = []
+        self.open = False
+
+    def toggle(self) -> None:
+        self.open = not self.open
+
+    def show(self) -> None:
+        self.open = True
+
+    def hide(self) -> None:
+        self.open = False
+
+    def send(self, user: str, msg: str) -> None:
+        self.messages.append((user, msg))
+        if len(self.messages) > self.max_messages:
+            self.messages.pop(0)
+
+    def history(self, limit: int | None = None):
+        if limit is None:
+            return list(self.messages)
+        return self.messages[-limit:]
+
+    def clear(self) -> None:
+        self.messages.clear()

--- a/hololive_coliseum/cheat_detection_manager.py
+++ b/hololive_coliseum/cheat_detection_manager.py
@@ -1,0 +1,11 @@
+class CheatDetectionManager:
+    """Detect basic suspicious activity such as impossible speed."""
+
+    def __init__(self):
+        self.flags = []
+
+    def check_speed(self, speed: float, max_speed: float) -> bool:
+        if speed > max_speed:
+            self.flags.append("speed")
+            return True
+        return False

--- a/hololive_coliseum/cluster_manager.py
+++ b/hololive_coliseum/cluster_manager.py
@@ -1,0 +1,13 @@
+class ClusterManager:
+    """Track servers participating in a multi-node cluster."""
+
+    def __init__(self) -> None:
+        self.nodes: list[str] = []
+
+    def register(self, address: str) -> None:
+        if address not in self.nodes:
+            self.nodes.append(address)
+
+    def unregister(self, address: str) -> None:
+        if address in self.nodes:
+            self.nodes.remove(address)

--- a/hololive_coliseum/combat_manager.py
+++ b/hololive_coliseum/combat_manager.py
@@ -1,0 +1,22 @@
+class CombatManager:
+    """Handle basic turn order and engagement logic."""
+
+    def __init__(self) -> None:
+        self.participants: list = []
+        self.index = 0
+
+    def add(self, actor) -> None:
+        """Add a combatant to the turn list."""
+        self.participants.append(actor)
+
+    def remove(self, actor) -> None:
+        if actor in self.participants:
+            self.participants.remove(actor)
+
+    def next_actor(self):
+        """Return the next actor in the turn order."""
+        if not self.participants:
+            return None
+        actor = self.participants[self.index % len(self.participants)]
+        self.index += 1
+        return actor

--- a/hololive_coliseum/companion_manager.py
+++ b/hololive_coliseum/companion_manager.py
@@ -1,0 +1,10 @@
+class CompanionManager:
+    """Assign a single companion to each player."""
+    def __init__(self):
+        self.companions = {}
+
+    def assign(self, player_id: str, companion: str) -> None:
+        self.companions[player_id] = companion
+
+    def get(self, player_id: str):
+        return self.companions.get(player_id)

--- a/hololive_coliseum/crafting_manager.py
+++ b/hololive_coliseum/crafting_manager.py
@@ -1,0 +1,28 @@
+class CraftingManager:
+    """Manage crafting recipes and craft items from an inventory."""
+
+    def __init__(self) -> None:
+        self._recipes: dict[str, dict[str, int]] = {}
+        self._results: dict[str, str] = {}
+
+    def add_recipe(self, name: str, ingredients: dict[str, int], result: str) -> None:
+        """Register a recipe by name."""
+        self._recipes[name] = dict(ingredients)
+        self._results[name] = result
+
+    def craft(self, name: str, inventory) -> str | None:
+        """Craft the recipe if all ingredients are present.
+        The ``inventory`` object must provide ``count`` and ``remove`` methods
+        and ``add`` to receive the crafted item.
+        Returns the crafted item or ``None`` if requirements are not met."""
+        req = self._recipes.get(name)
+        if not req:
+            return None
+        for item, cnt in req.items():
+            if getattr(inventory, "count")(item) < cnt:
+                return None
+        for item, cnt in req.items():
+            getattr(inventory, "remove")(item, cnt)
+        result = self._results[name]
+        getattr(inventory, "add")(result)
+        return result

--- a/hololive_coliseum/currency_manager.py
+++ b/hololive_coliseum/currency_manager.py
@@ -1,0 +1,17 @@
+class CurrencyManager:
+    """Track balances of in-game currency."""
+    def __init__(self, starting: int = 0):
+        self.balance = starting
+
+    def add(self, amount: int) -> int:
+        self.balance += amount
+        return self.balance
+
+    def spend(self, amount: int) -> bool:
+        if amount <= self.balance:
+            self.balance -= amount
+            return True
+        return False
+
+    def get_balance(self) -> int:
+        return self.balance

--- a/hololive_coliseum/damage_manager.py
+++ b/hololive_coliseum/damage_manager.py
@@ -1,0 +1,12 @@
+class DamageManager:
+    """Compute final damage values and apply them to targets."""
+
+    def calculate(self, base: int, defense: int = 0, multiplier: float = 1.0) -> int:
+        amount = max(base - defense, 0)
+        return int(amount * multiplier)
+
+    def apply(self, target, base: int, **kwargs) -> int:
+        dmg = self.calculate(base, **kwargs)
+        if hasattr(target, "take_damage"):
+            target.take_damage(dmg)
+        return dmg

--- a/hololive_coliseum/data_protection_manager.py
+++ b/hololive_coliseum/data_protection_manager.py
@@ -1,0 +1,13 @@
+class DataProtectionManager:
+    """Provide simple XOR encryption for data in transit."""
+
+    def __init__(self, key: bytes = b""):
+        self.key = key
+
+    def encrypt(self, data: bytes) -> bytes:
+        if not self.key:
+            return data
+        return bytes(b ^ self.key[i % len(self.key)] for i, b in enumerate(data))
+
+    def decrypt(self, data: bytes) -> bytes:
+        return self.encrypt(data)

--- a/hololive_coliseum/dungeon_manager.py
+++ b/hololive_coliseum/dungeon_manager.py
@@ -1,0 +1,11 @@
+class DungeonManager:
+    """Handle dungeon lockouts for players."""
+    def __init__(self):
+        self.lockouts = {}
+
+    def set_lockout(self, player_id: str, dungeon: str, expires: int) -> None:
+        self.lockouts[(player_id, dungeon)] = expires
+
+    def can_enter(self, player_id: str, dungeon: str, now: int) -> bool:
+        end = self.lockouts.get((player_id, dungeon))
+        return end is None or now >= end

--- a/hololive_coliseum/economy_manager.py
+++ b/hololive_coliseum/economy_manager.py
@@ -1,0 +1,14 @@
+class EconomyManager:
+    """Keep track of item prices."""
+
+    def __init__(self) -> None:
+        self._prices: dict[str, int] = {}
+
+    def set_price(self, item: str, price: int) -> None:
+        self._prices[item] = price
+
+    def get_price(self, item: str) -> int:
+        return self._prices.get(item, 0)
+
+    def remove_price(self, item: str) -> None:
+        self._prices.pop(item, None)

--- a/hololive_coliseum/effect_manager.py
+++ b/hololive_coliseum/effect_manager.py
@@ -1,0 +1,8 @@
+class EffectManager:
+    """Track triggered visual effects."""
+
+    def __init__(self):
+        self.active = []
+
+    def trigger(self, effect: str) -> None:
+        self.active.append(effect)

--- a/hololive_coliseum/emote_manager.py
+++ b/hololive_coliseum/emote_manager.py
@@ -1,0 +1,11 @@
+class EmoteManager:
+    """Keep a table of available emotes."""
+
+    def __init__(self):
+        self.emotes = {"wave": ":)", "dance": "<(^_^<)"}
+
+    def get(self, name: str):
+        return self.emotes.get(name)
+
+    def add(self, name: str, value: str) -> None:
+        self.emotes[name] = value

--- a/hololive_coliseum/environment_manager.py
+++ b/hololive_coliseum/environment_manager.py
@@ -1,0 +1,10 @@
+class EnvironmentManager:
+    """Track environment settings like weather or time of day."""
+    def __init__(self):
+        self.settings = {}
+
+    def set(self, key: str, value) -> None:
+        self.settings[key] = value
+
+    def get(self, key: str, default=None):
+        return self.settings.get(key, default)

--- a/hololive_coliseum/equipment_manager.py
+++ b/hololive_coliseum/equipment_manager.py
@@ -1,0 +1,23 @@
+class EquipmentManager:
+    """Manage equipment slots for a player."""
+
+    def __init__(self) -> None:
+        self.slots = {
+            "weapon": None,
+            "armor": None,
+            "accessory": None,
+        }
+
+    def equip(self, slot: str, item) -> None:
+        """Equip an item in the given slot."""
+        if slot in self.slots:
+            self.slots[slot] = item
+
+    def unequip(self, slot: str) -> None:
+        """Remove whatever is equipped in the slot."""
+        if slot in self.slots:
+            self.slots[slot] = None
+
+    def get(self, slot: str):
+        """Return the item equipped in the slot or ``None``."""
+        return self.slots.get(slot)

--- a/hololive_coliseum/event_manager.py
+++ b/hololive_coliseum/event_manager.py
@@ -1,0 +1,10 @@
+class EventManager:
+    """Track triggered world events."""
+    def __init__(self):
+        self.history = []
+
+    def trigger(self, name: str) -> None:
+        self.history.append(name)
+
+    def get_history(self):
+        return list(self.history)

--- a/hololive_coliseum/experience_manager.py
+++ b/hololive_coliseum/experience_manager.py
@@ -1,0 +1,17 @@
+class ExperienceManager:
+    """Handle experience gain and leveling."""
+
+    def __init__(self, level: int = 1, xp: int = 0, threshold: int = 100) -> None:
+        self.level = level
+        self.xp = xp
+        self.threshold = threshold
+
+    def add_xp(self, amount: int) -> bool:
+        """Add experience and return True if a level-up occurred."""
+        self.xp += amount
+        leveled = False
+        while self.xp >= self.threshold:
+            self.xp -= self.threshold
+            self.level += 1
+            leveled = True
+        return leveled

--- a/hololive_coliseum/friend_manager.py
+++ b/hololive_coliseum/friend_manager.py
@@ -1,0 +1,16 @@
+class FriendManager:
+    """Keep track of friends."""
+    def __init__(self):
+        self.friends = set()
+
+    def add_friend(self, user: str) -> None:
+        self.friends.add(user)
+
+    def remove_friend(self, user: str) -> None:
+        self.friends.discard(user)
+
+    def is_friend(self, user: str) -> bool:
+        return user in self.friends
+
+    def list_friends(self):
+        return sorted(self.friends)

--- a/hololive_coliseum/game.py
+++ b/hololive_coliseum/game.py
@@ -1,0 +1,1024 @@
+import os
+import pygame
+
+from .player import (
+    PlayerCharacter,
+    GuraPlayer,
+    WatsonPlayer,
+    InaPlayer,
+    KiaraPlayer,
+    CalliopePlayer,
+    FaunaPlayer,
+    KroniiPlayer,
+    IRySPlayer,
+    MumeiPlayer,
+    BaelzPlayer,
+    FubukiPlayer,
+    MikoPlayer,
+    AquaPlayer,
+    PekoraPlayer,
+    MarinePlayer,
+    SuiseiPlayer,
+    AyamePlayer,
+    NoelPlayer,
+    FlarePlayer,
+    SubaruPlayer,
+    SoraPlayer,
+    Enemy,
+)
+from .projectile import Projectile, ExplodingProjectile
+from .melee_attack import MeleeAttack
+from .gravity_zone import GravityZone
+from .hazards import SpikeTrap, IceZone, LavaZone
+from .powerup import PowerUp
+from .healing_zone import HealingZone
+from .save_manager import load_settings, save_settings, wipe_saves
+from .network import NetworkManager
+from .node_registry import load_nodes
+from .keybind_manager import KeybindManager
+from .chat_manager import ChatManager
+from .menus import MenuMixin, MENU_BG_COLOR, MENU_TEXT_COLOR
+from .accounts import register_account, delete_account
+from .status_effects import StatusEffectManager, FreezeEffect, SlowEffect
+from .ai_manager import AIManager
+from .npc_manager import NPCManager
+from .ally_manager import AllyManager
+from .menu_manager import MenuManager
+from .game_state_manager import GameStateManager
+
+
+class Game(MenuMixin):
+    """Main game class with menus, AI opponents, networking and settings."""
+
+    def __init__(self, width: int = 800, height: int = 600):
+        os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+        pygame.init()
+        self.settings = load_settings()
+        self.width = self.settings.get("width", width)
+        self.height = self.settings.get("height", height)
+        self.volume = self.settings.get("volume", 1.0)
+        os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+        self.mixer_ready = False
+        try:
+            pygame.mixer.init()
+            pygame.mixer.music.set_volume(self.volume)
+            self.mixer_ready = True
+        except pygame.error:
+            self.mixer_ready = False
+        default_keys = {
+            "shoot": pygame.K_z,
+            "melee": pygame.K_x,
+            "jump": pygame.K_SPACE,
+            "block": pygame.K_LSHIFT,
+            "parry": pygame.K_c,
+            "dodge": pygame.K_LCTRL,
+            "special": pygame.K_v,
+        }
+        self.keybind_manager = KeybindManager(default_keys)
+        self.keybind_manager.load_from_dict(self.settings.get("key_bindings", {}))
+        self.key_bindings = self.keybind_manager.bindings
+        self.chat_manager = ChatManager()
+        self.chat_input = ""
+        pygame.joystick.init()
+        self.joysticks = [
+            pygame.joystick.Joystick(i) for i in range(pygame.joystick.get_count())
+        ]
+        for j in self.joysticks:
+            j.init()
+        default_controller = {
+            "shoot": 0,
+            "melee": 1,
+            "jump": 2,
+            "block": 4,
+            "parry": 5,
+            "dodge": 6,
+            "special": 3,
+        }
+        self.controller_bindings = self.settings.get(
+            "controller_bindings", default_controller
+        )
+        self.screen = pygame.display.set_mode((self.width, self.height))
+        pygame.display.set_caption("Hololive Coliseum")
+        self.clock = pygame.time.Clock()
+        self.running = False
+        self.state = "splash"  # splash -> main_menu -> howto/credits/scoreboard -> mode -> solo_multi -> mp_type -> char -> lobby -> map/chapter -> settings -> accounts -> playing -> paused -> victory/game_over
+        self.menu_index = 0
+        self.state_manager = GameStateManager(self.state)
+        self.menu_manager = MenuManager()
+        self.main_menu_options = [
+            "New Game",
+            "Settings",
+            "How to Play",
+            "Credits",
+            "Records",
+            "Exit",
+        ]
+        self.mode_options = ["Story", "Arena", "Custom", "Back"]
+        self.solo_multi_options = ["Solo", "Multiplayer", "Back"]
+        self.mp_type_options = ["Offline", "Online", "Back"]
+        self.online_multiplayer = False
+        self.pause_options = ["Resume", "Main Menu"]
+        self.game_over_options = ["Play Again", "Main Menu"]
+        self.victory_options = ["Play Again", "Main Menu"]
+        self.final_time = 0
+        self.end_time = 0
+        self.show_end_options = False
+        self.best_time = self.settings.get("best_time", 0)
+        self.best_score = self.settings.get("best_score", 0)
+        self.score = 0
+        self.show_fps = self.settings.get("show_fps", False)
+        self.settings_options = [
+            "Key Bindings",
+            "Controller Bindings",
+            "Window Size",
+            "Volume",
+            "Show FPS",
+            "Reset Records",
+            "Wipe Saves",
+            "Node Settings",
+            "Accounts",
+            "Back",
+        ]
+        self.info_options = ["Back"]
+        self.key_options = [
+            "jump",
+            "shoot",
+            "melee",
+            "block",
+            "parry",
+            "dodge",
+            "special",
+            "Back",
+        ]
+        self.controller_options = list(self.key_options)
+        self.rebind_action: str | None = None
+        self.node_options = ["Start Node", "Stop Node", "Latency Helper", "Back"]
+        self.account_options = ["Register Account", "Delete Account", "Back"]
+        self.account_id = "player"
+        self.network_manager: NetworkManager | None = None
+        self.node_hosting = False
+        self.latency_helper = False
+        self.characters = [
+            "Gawr Gura",
+            "Watson Amelia",
+            "Ninomae Ina'nis",
+            "Takanashi Kiara",
+            "Mori Calliope",
+            "Ceres Fauna",
+            "Ouro Kronii",
+            "IRyS",
+            "Nanashi Mumei",
+            "Hakos Baelz",
+            "Shirakami Fubuki",
+            "Sakura Miko",
+            "Minato Aqua",
+            "Usada Pekora",
+            "Houshou Marine",
+            "Hoshimachi Suisei",
+            "Nakiri Ayame",
+            "Shirogane Noel",
+            "Shiranui Flare",
+            "Oozora Subaru",
+            "Tokino Sora",
+        ]
+        self.maps = ["Default"]
+        self.chapters = [f"Chapter {i}" for i in range(1, 21)]
+        self.difficulty_levels = ["Easy", "Normal", "Hard"]
+        self.difficulty_index = 1
+        self.character_menu_options = self.characters + [
+            "Add AI Player",
+            "Difficulty",
+            "Continue",
+            "Back",
+        ]
+        self.map_menu_options = self.maps + ["Back"]
+        self.chapter_menu_options = self.chapters + ["Back"]
+        self.lobby_options = ["Start Game", "Back"]
+        self.human_players = 1
+        self.ai_players = 0
+        self.player_names = ["Player 1"]
+        self.multiplayer = False
+        self.selected_mode: str | None = None
+        self.selected_character: str | None = None
+        self.selected_map: str | None = None
+        self.selected_chapter: str | None = None
+        image_dir = os.path.join(os.path.dirname(__file__), "..", "Images")
+
+        def _create_icon(text: str, size=(64, 64)) -> pygame.Surface:
+            surf = pygame.Surface(size)
+            surf.fill((200, 200, 200))
+            font = pygame.font.SysFont(None, 20)
+            label = font.render(text, True, (0, 0, 0))
+            surf.blit(label, label.get_rect(center=(size[0] // 2, size[1] // 2)))
+            return surf
+
+        def _load(name: str, size=(64, 64)) -> pygame.Surface:
+            path = os.path.join(image_dir, name)
+            if os.path.exists(path):
+                return pygame.image.load(path).convert_alpha()
+            return _create_icon(os.path.splitext(name)[0], size)
+
+        self.character_images = {
+            "Gawr Gura": _load("Gawr_Gura_right.png"),
+            "Watson Amelia": _load("Watson_Amelia_right.png"),
+            "Ninomae Ina'nis": _load("Ninomae_Inanis_right.png"),
+            "Takanashi Kiara": _load("Takanashi_Kiara_right.png"),
+            "Mori Calliope": _load("Mori_Calliope_right.png"),
+            "Ceres Fauna": _load("Ceres_Fauna_right.png"),
+            "Ouro Kronii": _load("Ouro_Kronii_right.png"),
+            "IRyS": _load("IRyS_right.png"),
+            "Nanashi Mumei": _load("Nanashi_Mumei_right.png"),
+            "Hakos Baelz": _load("Hakos_Baelz_right.png"),
+            "Shirakami Fubuki": _load("Shirakami_Fubuki_right.png"),
+            "Sakura Miko": _load("Sakura_Miko_right.png"),
+            "Minato Aqua": _load("Minato_Aqua_right.png"),
+            "Usada Pekora": _load("Usada_Pekora_right.png"),
+            "Houshou Marine": _load("Houshou_Marine_right.png"),
+            "Hoshimachi Suisei": _load("Hoshimachi_Suisei_right.png"),
+            "Nakiri Ayame": _load("Nakiri_Ayame_right.png"),
+            "Shirogane Noel": _load("Shirogane_Noel_right.png"),
+            "Shiranui Flare": _load("Shiranui_Flare_right.png"),
+            "Oozora Subaru": _load("Oozora_Subaru_right.png"),
+            "Tokino Sora": _load("Tokino_Sora_right.png"),
+        }
+        self.map_images = {
+            "Default": _load("map_default.png"),
+        }
+        self.chapter_images = {
+            f"Chapter {i}": _load(f"chapter{i}.png") for i in range(1, 21)
+        }
+        self.title_font = pygame.font.SysFont(None, 64)
+        self.menu_font = pygame.font.SysFont(None, 32)
+        self.menu_drawers = {
+            "splash": self._draw_menu,
+            "main_menu": lambda: self._draw_option_menu("Main Menu", self.main_menu_options),
+            "mode": lambda: self._draw_option_menu("Game Type", self.mode_options),
+            "solo_multi": lambda: self._draw_option_menu("Players", self.solo_multi_options),
+            "mp_type": lambda: self._draw_option_menu("Multiplayer", self.mp_type_options),
+            "char": self._draw_character_menu,
+            "map": self._draw_map_menu,
+            "chapter": self._draw_chapter_menu,
+            "lobby": self._draw_lobby_menu,
+            "settings": self._draw_settings_menu,
+            "key_bindings": self._draw_key_bindings_menu,
+            "controller_bindings": self._draw_controller_bindings_menu,
+            "rebind": self._draw_rebind_prompt,
+            "rebind_controller": self._draw_rebind_controller_prompt,
+            "node_settings": self._draw_node_menu,
+            "accounts": self._draw_accounts_menu,
+            "howto": self._draw_how_to_play,
+            "credits": self._draw_credits,
+            "scoreboard": self._draw_scoreboard_menu,
+            "paused": self._draw_pause_menu,
+            "victory": self._draw_victory_menu,
+            "game_over": self._draw_game_over_menu,
+        }
+
+        # Stage setup
+        self.ground_y = self.height - 50
+        self.next_powerup_time = 0
+        self.last_enemy_damage = 0
+        self.level_start_time = 0
+        self.level_limit = 60  # seconds
+        self.status_manager = StatusEffectManager()
+        self.npc_manager = NPCManager()
+        self.ai_manager = AIManager(self.npc_manager.enemies)
+        self.ally_manager = AllyManager(self.npc_manager.allies)
+        self._setup_level()
+
+    def _setup_level(self) -> None:
+        """Initialize or reset gameplay objects based on the chosen character."""
+        self.final_time = 0
+        self.end_time = 0
+        self.show_end_options = False
+        self.status_manager._effects.clear()
+        self.score = 0
+        image_dir = os.path.join(os.path.dirname(__file__), "..", "Images")
+        char_map = {
+            "Watson Amelia": (WatsonPlayer, "Watson_Amelia_right.png"),
+            "Ninomae Ina'nis": (InaPlayer, "Ninomae_Inanis_right.png"),
+            "Takanashi Kiara": (KiaraPlayer, "Takanashi_Kiara_right.png"),
+            "Mori Calliope": (CalliopePlayer, "Mori_Calliope_right.png"),
+            "Ceres Fauna": (FaunaPlayer, "Ceres_Fauna_right.png"),
+            "Ouro Kronii": (KroniiPlayer, "Ouro_Kronii_right.png"),
+            "IRyS": (IRySPlayer, "IRyS_right.png"),
+            "Nanashi Mumei": (MumeiPlayer, "Nanashi_Mumei_right.png"),
+            "Hakos Baelz": (BaelzPlayer, "Hakos_Baelz_right.png"),
+            "Shirakami Fubuki": (FubukiPlayer, "Shirakami_Fubuki_right.png"),
+            "Sakura Miko": (MikoPlayer, "Sakura_Miko_right.png"),
+            "Minato Aqua": (AquaPlayer, "Minato_Aqua_right.png"),
+            "Usada Pekora": (PekoraPlayer, "Usada_Pekora_right.png"),
+            "Houshou Marine": (MarinePlayer, "Houshou_Marine_right.png"),
+            "Hoshimachi Suisei": (SuiseiPlayer, "Hoshimachi_Suisei_right.png"),
+            "Nakiri Ayame": (AyamePlayer, "Nakiri_Ayame_right.png"),
+            "Shirogane Noel": (NoelPlayer, "Shirogane_Noel_right.png"),
+            "Shiranui Flare": (FlarePlayer, "Shiranui_Flare_right.png"),
+            "Oozora Subaru": (SubaruPlayer, "Oozora_Subaru_right.png"),
+            "Tokino Sora": (SoraPlayer, "Tokino_Sora_right.png"),
+        }
+        player_cls, img_name = char_map.get(
+            self.selected_character, (GuraPlayer, "Gawr_Gura_right.png")
+        )
+        img = os.path.join(image_dir, img_name)
+        self.player = player_cls(100, self.ground_y - 60, img)
+        self.difficulty = self.difficulty_levels[self.difficulty_index]
+        self.all_sprites = pygame.sprite.Group(self.player)
+        self.projectiles = pygame.sprite.Group()
+        self.melee_attacks = pygame.sprite.Group()
+        self.gravity_zones = pygame.sprite.Group()
+        self.healing_zones = pygame.sprite.Group()
+        self.hazards = pygame.sprite.Group()
+        self.powerups = pygame.sprite.Group()
+        self.enemies = pygame.sprite.Group()
+        self.npc_manager.enemies = self.enemies
+        self.npc_manager.allies.empty()
+        self.ai_manager.enemies = self.enemies
+        # Reset timers when starting a new level
+        self.next_powerup_time = 0
+        self.last_enemy_damage = 0
+        self.last_hazard_damage = 0
+        for i in range(self.ai_players):
+            e = Enemy(
+                300 + i * 60,
+                self.ground_y - 60,
+                os.path.join(image_dir, "enemy_right.png"),
+                difficulty=self.difficulty,
+            )
+            e.last_ai_action = -e.AI_LEVELS[self.difficulty]["react_ms"]
+            self.enemies.add(e)
+            self.all_sprites.add(e)
+
+        zone_rect = pygame.Rect(self.width // 2 - 50, self.ground_y - 150, 100, 50)
+        self.low_gravity_zone = GravityZone(zone_rect, 0.2)
+        self.gravity_zones.add(self.low_gravity_zone)
+        self.all_sprites.add(self.low_gravity_zone)
+        high_rect = pygame.Rect(self.width // 2 + 70, self.ground_y - 120, 80, 40)
+        self.high_gravity_zone = GravityZone(high_rect, 2.0)
+        self.gravity_zones.add(self.high_gravity_zone)
+        self.all_sprites.add(self.high_gravity_zone)
+        spike = SpikeTrap(pygame.Rect(self.width // 3, self.ground_y - 20, 40, 20))
+        ice = IceZone(pygame.Rect(self.width // 2 + 80, self.ground_y - 20, 60, 20))
+        lava = LavaZone(pygame.Rect(self.width // 2 - 100, self.ground_y - 20, 60, 20))
+        self.hazards.add(spike, ice, lava)
+        self.all_sprites.add(spike, ice, lava)
+
+    def _cycle_volume(self) -> None:
+        """Cycle master volume between 0%, 50% and 100%."""
+        steps = [0.0, 0.5, 1.0]
+        current = min(steps, key=lambda v: abs(v - self.volume))
+        idx = steps.index(current)
+        self.volume = steps[(idx + 1) % len(steps)]
+        if self.mixer_ready:
+            pygame.mixer.music.set_volume(self.volume)
+
+    def _set_state(self, state: str) -> None:
+        """Helper to update game and managers with a new state."""
+        self.state = state
+        self.state_manager.change(state)
+        self.menu_manager.reset()
+        self.menu_index = self.menu_manager.index
+
+    def execute_account_option(self, option: str) -> None:
+        """Handle register/delete actions for tests and menus."""
+        if option == "Register Account":
+            register_account(self.account_id, "user", "PUBKEY")
+        elif option == "Delete Account":
+            delete_account(self.account_id)
+
+    def start_node(self) -> None:
+        """Begin hosting a blockchain node."""
+        if self.network_manager is None:
+            self.network_manager = NetworkManager(host=True, relay_mode=self.latency_helper)
+            self.network_manager.broadcast_announce(load_nodes())
+            if self.latency_helper:
+                self.network_manager.offer_relay(load_nodes())
+            self.node_hosting = True
+
+    def stop_node(self) -> None:
+        """Stop hosting the blockchain node."""
+        if self.network_manager is not None:
+            try:
+                self.network_manager.sock.close()
+            except OSError:
+                pass
+            self.network_manager = None
+        self.node_hosting = False
+
+    def _poll_network(self) -> None:
+        if self.network_manager is not None:
+            self.network_manager.poll()
+            self.network_manager.process_reliable()
+
+    def _handle_collisions(self) -> None:
+        """Handle combat collisions between attacks and sprites."""
+        now = pygame.time.get_ticks()
+        for proj in list(self.projectiles):
+            if getattr(proj, "from_enemy", False):
+                if self.player.rect.colliderect(proj.rect):
+                    if getattr(self.player, "shield_active", False):
+                        proj.kill()
+                    else:
+                        self.player.take_damage(10)
+                        proj.kill()
+                continue
+            hits = pygame.sprite.spritecollide(proj, self.enemies, False)
+            if hits:
+                for enemy in hits:
+                    if getattr(proj, "grapple", False):
+                        enemy.rect.centerx = self.player.rect.centerx
+                        enemy.pos.x = enemy.rect.x
+                    elif getattr(proj, "freeze", False):
+                        self.status_manager.add_effect(enemy, FreezeEffect())
+                        enemy.take_damage(5)
+                    elif getattr(proj, "slow", False):
+                        self.status_manager.add_effect(enemy, SlowEffect())
+                        enemy.take_damage(5)
+                    else:
+                        enemy.take_damage(10)
+                    if enemy.health == 0:
+                        enemy.kill()
+                        self.score += 1
+                if not getattr(proj, "pierce", False):
+                    proj.kill()
+        for attack in list(self.melee_attacks):
+            if getattr(attack, "from_enemy", False):
+                if attack.rect.colliderect(self.player.rect):
+                    self.player.take_damage(15)
+                attack.kill()
+                continue
+            hits = pygame.sprite.spritecollide(attack, self.enemies, False)
+            if hits:
+                for enemy in hits:
+                    enemy.take_damage(15)
+                    if enemy.health == 0:
+                        enemy.kill()
+                        self.score += 1
+            attack.kill()
+        if (
+            pygame.sprite.spritecollideany(self.player, self.enemies)
+            and now - self.last_enemy_damage >= 500
+        ):
+            self.player.take_damage(10)
+            self.last_enemy_damage = now
+
+    def run(self):
+        """Start the main game loop."""
+        self.running = True
+        while self.running:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    self.running = False
+                elif self.state == "splash" and event.type in (
+                    pygame.KEYDOWN,
+                    pygame.MOUSEBUTTONDOWN,
+                    pygame.JOYBUTTONDOWN,
+                ):
+                    self._set_state("main_menu")
+                    self.menu_index = 0
+                elif (
+                    self.state == "playing"
+                    and event.type == pygame.KEYDOWN
+                    and event.key == pygame.K_ESCAPE
+                ):
+                    self._set_state("paused")
+                    self.menu_index = 0
+                elif (
+                    self.state == "paused"
+                    and event.type == pygame.KEYDOWN
+                    and event.key == pygame.K_ESCAPE
+                ):
+                    self._set_state("playing")
+                elif (
+                    self.state == "playing"
+                    and event.type == pygame.KEYDOWN
+                    and event.key == pygame.K_RETURN
+                ):
+                    if self.chat_manager.open:
+                        if self.chat_input.strip():
+                            sender = self.player_names[0] if self.player_names else "Player"
+                            self.chat_manager.send(sender, self.chat_input)
+                        self.chat_input = ""
+                        self.chat_manager.hide()
+                    else:
+                        self.chat_manager.show()
+                    continue
+                elif (
+                    self.state == "playing"
+                    and self.chat_manager.open
+                    and event.type == pygame.KEYDOWN
+                ):
+                    if event.key == pygame.K_BACKSPACE:
+                        self.chat_input = self.chat_input[:-1]
+                    elif event.unicode and event.unicode.isprintable():
+                        self.chat_input += event.unicode
+                    continue
+                elif (
+                    self.state
+                    in {
+                        "main_menu",
+                        "mode",
+                        "solo_multi",
+                        "settings",
+                        "key_bindings",
+                        "controller_bindings",
+                        "char",
+                        "map",
+                        "chapter",
+                        "mp_type",
+                        "paused",
+                        "victory",
+                        "game_over",
+                    }
+                    and event.type == pygame.KEYDOWN
+                    and (
+                        self.state not in {"victory", "game_over"}
+                        or self.show_end_options
+                    )
+                ):
+                    options = {
+                        "main_menu": self.main_menu_options,
+                        "mode": self.mode_options,
+                        "solo_multi": self.solo_multi_options,
+                        "mp_type": self.mp_type_options,
+                        "settings": self.settings_options,
+                        "node_settings": self.node_options,
+                        "accounts": self.account_options,
+                        "howto": self.info_options,
+                        "credits": self.info_options,
+                        "scoreboard": self.info_options,
+                        "key_bindings": self.key_options,
+                        "controller_bindings": self.controller_options,
+                        "char": self.character_menu_options,
+                        "map": self.map_menu_options,
+                        "chapter": self.chapter_menu_options,
+                        "lobby": self.lobby_options,
+                        "paused": self.pause_options,
+                        "victory": self.victory_options,
+                        "game_over": self.game_over_options,
+                    }[self.state]
+                    if (
+                        self.state == "char"
+                        and event.key == pygame.K_j
+                        and self.multiplayer
+                        and not self.online_multiplayer
+                    ):
+                        if self.human_players < 4:
+                            self.human_players += 1
+                            self.player_names.append(f"Player {self.human_players}")
+                        continue
+                    if event.key == pygame.K_UP:
+                        self.menu_manager.move(-1, len(options))
+                        self.menu_index = self.menu_manager.index
+                    elif event.key == pygame.K_DOWN:
+                        self.menu_manager.move(1, len(options))
+                        self.menu_index = self.menu_manager.index
+                    elif (
+                        self.state == "char"
+                        and options[self.menu_index] == "Difficulty"
+                        and event.key in (pygame.K_LEFT, pygame.K_RIGHT)
+                    ):
+                        if event.key == pygame.K_LEFT:
+                            self.difficulty_index = (self.difficulty_index - 1) % len(
+                                self.difficulty_levels
+                            )
+                        else:
+                            self.difficulty_index = (self.difficulty_index + 1) % len(
+                                self.difficulty_levels
+                            )
+                    elif (
+                        self.state == "settings"
+                        and options[self.menu_index] == "Volume"
+                        and event.key in (pygame.K_LEFT, pygame.K_RIGHT)
+                    ):
+                        if event.key == pygame.K_LEFT:
+                            self.volume = max(0.0, self.volume - 0.1)
+                        else:
+                            self.volume = min(1.0, self.volume + 0.1)
+                        if self.mixer_ready:
+                            pygame.mixer.music.set_volume(self.volume)
+                    elif (
+                        self.state == "key_bindings"
+                        and options[self.menu_index] != "Back"
+                        and event.key in (pygame.K_RETURN, pygame.K_SPACE)
+                    ):
+                        self.rebind_action = options[self.menu_index]
+                        self._set_state("rebind")
+                    elif (
+                        self.state == "controller_bindings"
+                        and options[self.menu_index] != "Back"
+                        and event.key in (pygame.K_RETURN, pygame.K_SPACE)
+                    ):
+                        self.rebind_action = options[self.menu_index]
+                        self._set_state("rebind_controller")
+                    elif (
+                        self.state == "key_bindings"
+                        and options[self.menu_index] == "Back"
+                        and event.key in (pygame.K_RETURN, pygame.K_SPACE)
+                    ):
+                        self._set_state("settings")
+                        self.menu_index = 0
+                    elif (
+                        self.state == "controller_bindings"
+                        and options[self.menu_index] == "Back"
+                        and event.key in (pygame.K_RETURN, pygame.K_SPACE)
+                    ):
+                        self._set_state("settings")
+                        self.menu_index = 0
+                    elif event.key in (pygame.K_RETURN, pygame.K_SPACE):
+                        choice = options[self.menu_index]
+                        if self.state == "main_menu":
+                            if choice == "New Game":
+                                self._set_state("mode")
+                                self.menu_index = 0
+                            elif choice == "Settings":
+                                self._set_state("settings")
+                                self.menu_index = 0
+                            elif choice == "How to Play":
+                                self._set_state("howto")
+                                self.menu_index = 0
+                            elif choice == "Credits":
+                                self._set_state("credits")
+                                self.menu_index = 0
+                            elif choice == "Records":
+                                self._set_state("scoreboard")
+                                self.menu_index = 0
+                            elif choice == "Exit":
+                                self.running = False
+                        elif self.state == "mode":
+                            if choice == "Back":
+                                self._set_state("main_menu")
+                                self.menu_index = 0
+                            else:
+                                self.selected_mode = choice
+                                self.human_players = 1
+                                self.ai_players = 0
+                                self._set_state("solo_multi")
+                                self.menu_index = 0
+                        elif self.state == "solo_multi":
+                            if choice == "Back":
+                                self._set_state("mode")
+                                self.menu_index = 0
+                            else:
+                                self.multiplayer = choice == "Multiplayer"
+                                if choice == "Solo":
+                                    self._set_state("char")
+                                else:
+                                    self._set_state("mp_type")
+                                self.menu_index = 0
+                        elif self.state == "mp_type":
+                            if choice == "Back":
+                                self._set_state("solo_multi")
+                                self.menu_index = 0
+                            else:
+                                self.online_multiplayer = choice == "Online"
+                                self._set_state("char")
+                                self.menu_index = 0
+                        elif self.state == "char":
+                            if choice == "Add AI Player":
+                                if self.ai_players < 4 - self.human_players:
+                                    self.ai_players += 1
+                            elif choice == "Difficulty":
+                                self.difficulty_index = (
+                                    self.difficulty_index + 1
+                                ) % len(self.difficulty_levels)
+                            elif choice == "Continue":
+                                if self.selected_character is None and self.characters:
+                                    self.selected_character = self.characters[0]
+                                if self.multiplayer:
+                                    self.player_names = [
+                                        f"Player {i+1}"
+                                        for i in range(self.human_players)
+                                    ]
+                                    self.player_names += [
+                                        f"AI {i+1}" for i in range(self.ai_players)
+                                    ]
+                                    self._set_state("lobby")
+                                elif self.selected_mode == "Story":
+                                    self._set_state("chapter")
+                                else:
+                                    self._set_state("map")
+                                self.menu_index = 0
+                            elif choice == "Back":
+                                self.state = (
+                                    "mp_type" if self.multiplayer else "solo_multi"
+                                )
+                                self.menu_index = 0
+                            else:
+                                self.selected_character = choice
+                        elif self.state == "lobby":
+                            if choice == "Back":
+                                self._set_state("char")
+                                self.menu_index = 0
+                            elif choice == "Start Game":
+                                if self.selected_mode == "Story":
+                                    self._set_state("chapter")
+                                else:
+                                    self._set_state("map")
+                                self.menu_index = 0
+                        elif self.state == "map":
+                            if choice == "Back":
+                                if self.multiplayer:
+                                    self._set_state("lobby")
+                                else:
+                                    self._set_state("char")
+                                self.menu_index = 0
+                            else:
+                                self.selected_map = choice
+                                self._setup_level()
+                                self._set_state("playing")
+                                self.level_start_time = pygame.time.get_ticks()
+                        elif self.state == "chapter":
+                            if choice == "Back":
+                                if self.multiplayer:
+                                    self._set_state("lobby")
+                                else:
+                                    self._set_state("char")
+                                self.menu_index = 0
+                            else:
+                                self.selected_chapter = choice
+                                self._setup_level()
+                                self._set_state("playing")
+                                self.level_start_time = pygame.time.get_ticks()
+                        elif self.state == "settings":
+                            if choice == "Back":
+                                self._set_state("main_menu")
+                                self.menu_index = 0
+                            elif choice == "Key Bindings":
+                                self._set_state("key_bindings")
+                                self.menu_index = 0
+                            elif choice == "Controller Bindings":
+                                self._set_state("controller_bindings")
+                                self.menu_index = 0
+                            elif choice == "Window Size":
+                                if (self.width, self.height) == (800, 600):
+                                    self.width, self.height = 1024, 768
+                                else:
+                                    self.width, self.height = 800, 600
+                                self.screen = pygame.display.set_mode(
+                                    (self.width, self.height)
+                                )
+                            elif choice == "Volume":
+                                self._cycle_volume()
+                            elif choice == "Show FPS":
+                                self.show_fps = not self.show_fps
+                            elif choice == "Reset Records":
+                                self.best_time = 0
+                                self.best_score = 0
+                            elif choice == "Wipe Saves":
+                                wipe_saves()
+                            elif choice == "Node Settings":
+                                self._set_state("node_settings")
+                                self.menu_index = 0
+                            elif choice == "Accounts":
+                                self._set_state("accounts")
+                                self.menu_index = 0
+                        elif self.state == "node_settings":
+                            if choice == "Back":
+                                self._set_state("settings")
+                                self.menu_index = 0
+                            elif choice == "Start Node":
+                                self.start_node()
+                            elif choice == "Stop Node":
+                                self.stop_node()
+                            elif choice == "Latency Helper":
+                                self.latency_helper = not self.latency_helper
+                                if self.network_manager is not None:
+                                    self.network_manager.relay_mode = self.latency_helper
+                                    if self.latency_helper:
+                                        self.network_manager.offer_relay(load_nodes())
+                        elif self.state == "accounts":
+                            if choice == "Back":
+                                self._set_state("settings")
+                                self.menu_index = 0
+                            elif choice == "Register Account":
+                                self.execute_account_option("Register Account")
+                            elif choice == "Delete Account":
+                                self.execute_account_option("Delete Account")
+                        elif self.state in {"howto", "credits", "scoreboard"}:
+                            if choice == "Back":
+                                self._set_state("main_menu")
+                                self.menu_index = 0
+                        elif self.state == "paused":
+                            if choice == "Resume":
+                                self._set_state("playing")
+                            elif choice == "Main Menu":
+                                self._set_state("main_menu")
+                                self.menu_index = 0
+                        elif self.state == "game_over":
+                            if choice == "Play Again":
+                                self._set_state("char")
+                                self.menu_index = 0
+                            elif choice == "Main Menu":
+                                self._set_state("main_menu")
+                                self.menu_index = 0
+                        elif self.state == "victory":
+                            if choice == "Play Again":
+                                self._set_state("char")
+                                self.menu_index = 0
+                            elif choice == "Main Menu":
+                                self._set_state("main_menu")
+                                self.menu_index = 0
+                elif self.state == "rebind" and event.type == pygame.KEYDOWN:
+                    self.keybind_manager.set(self.rebind_action, event.key)
+                    self._set_state("key_bindings")
+                elif (
+                    self.state == "rebind_controller"
+                    and event.type == pygame.JOYBUTTONDOWN
+                ):
+                    self.controller_bindings[self.rebind_action] = event.button
+                    self._set_state("controller_bindings")
+            now = pygame.time.get_ticks()
+            self.status_manager.update(now)
+            if (
+                self.state in {"victory", "game_over"}
+                and not self.show_end_options
+                and now - self.end_time >= 3000
+            ):
+                self.show_end_options = True
+
+            drawer = self.menu_drawers.get(self.state)
+            if drawer is not None:
+                drawer()
+            else:
+                keys = pygame.key.get_pressed()
+
+                def action_pressed(action: str) -> bool:
+                    key = self.keybind_manager.get(action)
+                    if key is not None and keys[key]:
+                        return True
+                    for joy in self.joysticks:
+                        btn = self.controller_bindings.get(action)
+                        if btn is not None and joy.get_button(btn):
+                            return True
+                    return False
+
+                self.player.handle_input(keys, now, self.keybind_manager.bindings, action_pressed)
+                if action_pressed("special"):
+                    proj = self.player.special_attack(now)
+                    if isinstance(proj, HealingZone):
+                        self.healing_zones.add(proj)
+                        self.all_sprites.add(proj)
+                    elif proj:
+                        self.projectiles.add(proj)
+                        self.all_sprites.add(proj)
+                if action_pressed("shoot"):
+                    proj = self.player.shoot(now, pygame.mouse.get_pos())
+                    if proj:
+                        self.projectiles.add(proj)
+                        self.all_sprites.add(proj)
+                if action_pressed("melee"):
+                    melee = self.player.melee_attack(now)
+                    if melee:
+                        self.melee_attacks.add(melee)
+                        self.all_sprites.add(melee)
+                zone = pygame.sprite.spritecollideany(self.player, self.gravity_zones)
+                if zone:
+                    self.player.set_gravity_multiplier(zone.multiplier)
+                else:
+                    self.player.set_gravity_multiplier(1.0)
+                hazard = pygame.sprite.spritecollideany(self.player, self.hazards)
+                if hazard:
+                    if isinstance(hazard, SpikeTrap) and now - self.last_hazard_damage >= 500:
+                        self.player.take_damage(hazard.damage)
+                        self.last_hazard_damage = now
+                    if isinstance(hazard, LavaZone) and now - self.last_hazard_damage >= hazard.interval:
+                        self.player.take_damage(hazard.damage)
+                        self.last_hazard_damage = now
+                    if isinstance(hazard, IceZone):
+                        self.player.set_friction_multiplier(hazard.friction)
+                else:
+                    self.player.set_friction_multiplier(1.0)
+                extra = self.player.update(self.ground_y, now)
+                if isinstance(extra, pygame.sprite.Sprite):
+                    self.projectiles.add(extra)
+                    self.all_sprites.add(extra)
+                new_projs, new_melees = self.ai_manager.update(
+                    self.player, now, self.hazards, self.projectiles
+                )
+                for enemy, proj in new_projs:
+                    self.projectiles.add(proj)
+                    self.all_sprites.add(proj)
+                for enemy, melee in new_melees:
+                    self.melee_attacks.add(melee)
+                    self.all_sprites.add(melee)
+                for enemy in list(self.enemies):
+                    zone = pygame.sprite.spritecollideany(enemy, self.gravity_zones)
+                    if zone:
+                        enemy.set_gravity_multiplier(zone.multiplier)
+                    else:
+                        enemy.set_gravity_multiplier(1.0)
+                    hz = pygame.sprite.spritecollideany(enemy, self.hazards)
+                    if isinstance(hz, SpikeTrap):
+                        enemy.take_damage(hz.damage)
+                        if enemy.health == 0:
+                            enemy.kill()
+                            self.score += 1
+                    elif (
+                        isinstance(hz, LavaZone)
+                        and now - self.last_hazard_damage >= hz.interval
+                    ):
+                        enemy.take_damage(hz.damage)
+                        self.last_hazard_damage = now
+                    enemy.update(self.ground_y, now)
+                self.ally_manager.update(self.player, self.ground_y, now)
+                self.projectiles.update()
+                self.melee_attacks.update()
+                self.healing_zones.update()
+                self._handle_collisions()
+                self.powerups.update()
+                if now >= self.next_powerup_time:
+                    x = self.width // 2
+                    p = PowerUp(x, self.ground_y - 20, "heal")
+                    self.powerups.add(p)
+                    self.all_sprites.add(p)
+                    self.next_powerup_time = now + 5000
+                for zone in self.healing_zones:
+                    if zone.rect.colliderect(self.player.rect):
+                        self.player.health = min(
+                            self.player.max_health,
+                            self.player.health + zone.heal_rate,
+                        )
+                p = pygame.sprite.spritecollideany(self.player, self.powerups)
+                if p:
+                    if p.effect == "heal":
+                        self.player.health = self.player.max_health
+                    elif p.effect == "mana":
+                        self.player.mana = self.player.max_mana
+                    p.kill()
+                for proj in list(self.projectiles):
+                    if proj.rect.right < 0 or proj.rect.left > self.width:
+                        proj.kill()
+                if self.player.lives == 0:
+                    self.final_time = (now - self.level_start_time) // 1000
+                    if self.final_time > self.best_time:
+                        self.best_time = self.final_time
+                    if self.score > self.best_score:
+                        self.best_score = self.score
+                    self._set_state("game_over")
+                    self.end_time = now
+                    self.show_end_options = False
+                    self.menu_index = 0
+                    continue
+                self.screen.fill((0, 0, 0))
+                pygame.draw.rect(
+                    self.screen,
+                    (100, 100, 100),
+                    pygame.Rect(
+                        0, self.ground_y, self.width, self.height - self.ground_y
+                    ),
+                )
+                self.all_sprites.draw(self.screen)
+                self.player.draw_status(self.screen)
+                if self.chat_manager.open:
+                    chat_rect = pygame.Rect(10, self.height - 40, 300, 30)
+                    pygame.draw.rect(self.screen, (50, 50, 50), chat_rect)
+                    txt = self.menu_font.render(self.chat_input, True, (255, 255, 255))
+                    self.screen.blit(txt, (chat_rect.x + 5, chat_rect.y + 5))
+                elapsed = (now - self.level_start_time) // 1000
+                if elapsed >= self.level_limit or len(self.enemies) == 0:
+                    self.final_time = elapsed
+                    if self.final_time > self.best_time:
+                        self.best_time = self.final_time
+                    if self.score > self.best_score:
+                        self.best_score = self.score
+                    self._set_state("victory")
+                    self.end_time = now
+                    self.show_end_options = False
+                    self.menu_index = 0
+                    continue
+                timer_text = self.menu_font.render(
+                    f"Time: {elapsed}", True, (255, 255, 255)
+                )
+                self.screen.blit(timer_text, (self.width - 120, 10))
+                score_text = self.menu_font.render(
+                    f"Score: {self.score}", True, (255, 255, 255)
+                )
+                self.screen.blit(score_text, (10, 10))
+
+            self._poll_network()
+
+            pygame.display.flip()
+            self.clock.tick(60)
+        save_settings(
+            {
+                "width": self.width,
+                "height": self.height,
+                "volume": self.volume,
+                "best_time": self.best_time,
+                "best_score": self.best_score,
+                "show_fps": self.show_fps,
+                "key_bindings": self.keybind_manager.to_dict(),
+                "controller_bindings": self.controller_bindings,
+            }
+        )
+        pygame.quit()
+
+
+def main():
+    """Entry point for running the game via `python -m hololive_coliseum`."""
+    game = Game()
+    game.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/hololive_coliseum/game_state_manager.py
+++ b/hololive_coliseum/game_state_manager.py
@@ -1,0 +1,16 @@
+class GameStateManager:
+    """Simple helper to track the current and previous game states."""
+
+    def __init__(self, initial: str = "splash") -> None:
+        self.state = initial
+        self.previous = None
+
+    def change(self, state: str) -> None:
+        """Set a new state, remembering the old one."""
+        self.previous = self.state
+        self.state = state
+
+    def revert(self) -> None:
+        """Return to the previous state if available."""
+        if self.previous is not None:
+            self.state, self.previous = self.previous, self.state

--- a/hololive_coliseum/gravity_zone.py
+++ b/hololive_coliseum/gravity_zone.py
@@ -1,0 +1,14 @@
+import pygame
+
+class GravityZone(pygame.sprite.Sprite):
+    """Rectangular zone that modifies gravity for sprites inside it."""
+
+    def __init__(self, rect: pygame.Rect, multiplier: float) -> None:
+        super().__init__()
+        self.rect = rect
+        self.multiplier = multiplier
+        # For visualization (optional), we can make a semi-transparent surface
+        self.image = pygame.Surface(self.rect.size, pygame.SRCALPHA)
+        color = (0, 0, 255, 50) if multiplier > 1 else (255, 0, 0, 50)
+        self.image.fill(color)
+

--- a/hololive_coliseum/guild_manager.py
+++ b/hololive_coliseum/guild_manager.py
@@ -1,0 +1,20 @@
+class GuildManager:
+    """Manage guild membership and ranks."""
+    def __init__(self):
+        self.members = {}
+
+    def add_member(self, user: str, rank: str = "member") -> None:
+        self.members[user] = rank
+
+    def remove_member(self, user: str) -> None:
+        self.members.pop(user, None)
+
+    def set_rank(self, user: str, rank: str) -> None:
+        if user in self.members:
+            self.members[user] = rank
+
+    def get_rank(self, user: str):
+        return self.members.get(user)
+
+    def list_members(self):
+        return dict(self.members)

--- a/hololive_coliseum/hazards.py
+++ b/hololive_coliseum/hazards.py
@@ -1,0 +1,35 @@
+import pygame
+
+class SpikeTrap(pygame.sprite.Sprite):
+    """Rectangular hazard that damages sprites on contact."""
+
+    def __init__(self, rect: pygame.Rect, damage: int = 10) -> None:
+        super().__init__()
+        self.rect = rect
+        self.damage = damage
+        self.image = pygame.Surface(self.rect.size)
+        self.image.fill((200, 0, 0))
+        self.avoid = True
+
+class IceZone(pygame.sprite.Sprite):
+    """Zone with slippery surface reducing friction."""
+
+    def __init__(self, rect: pygame.Rect, friction: float = 0.5) -> None:
+        super().__init__()
+        self.rect = rect
+        self.friction = friction
+        self.image = pygame.Surface(self.rect.size, pygame.SRCALPHA)
+        self.image.fill((0, 200, 255, 80))
+        self.avoid = False
+
+class LavaZone(pygame.sprite.Sprite):
+    """Hazard zone that deals periodic damage while touched."""
+
+    def __init__(self, rect: pygame.Rect, damage: int = 5, interval: int = 300) -> None:
+        super().__init__()
+        self.rect = rect
+        self.damage = damage
+        self.interval = interval
+        self.image = pygame.Surface(self.rect.size, pygame.SRCALPHA)
+        self.image.fill((255, 100, 0, 120))
+        self.avoid = True

--- a/hololive_coliseum/healing_zone.py
+++ b/hololive_coliseum/healing_zone.py
@@ -1,0 +1,17 @@
+import pygame
+
+class HealingZone(pygame.sprite.Sprite):
+    """Zone that heals players standing inside it."""
+
+    def __init__(self, rect: pygame.Rect, heal_rate: int = 1, duration: int = 60) -> None:
+        super().__init__()
+        self.rect = rect
+        self.heal_rate = heal_rate
+        self.timer = duration
+        self.image = pygame.Surface(self.rect.size, pygame.SRCALPHA)
+        self.image.fill((0, 255, 0, 80))
+
+    def update(self) -> None:
+        self.timer -= 1
+        if self.timer <= 0:
+            self.kill()

--- a/hololive_coliseum/health_manager.py
+++ b/hololive_coliseum/health_manager.py
@@ -1,0 +1,20 @@
+class HealthManager:
+    """Track and modify a character's health."""
+
+    def __init__(self, max_health: int) -> None:
+        self.max_health = max_health
+        self.health = max_health
+
+    def take_damage(self, amount: int, blocking: bool = False, parrying: bool = False) -> int:
+        """Apply damage and return the new health value."""
+        if parrying:
+            return self.health
+        if blocking:
+            amount //= 2
+        self.health = max(0, self.health - amount)
+        return self.health
+
+    def heal(self, amount: int) -> int:
+        """Restore health and return the new value."""
+        self.health = min(self.max_health, self.health + amount)
+        return self.health

--- a/hololive_coliseum/holographic_compression.py
+++ b/hololive_coliseum/holographic_compression.py
@@ -1,0 +1,87 @@
+import base64
+import json
+import zlib
+import hashlib
+from typing import Tuple, Dict, Any, List
+
+ANCHOR = "HLPC"
+
+# Four color-coded anchor points define the bounding box of the
+# holographic pointcloud. They help reconstruct orientation and size
+# when decoding the payload.
+ANCHOR_POINTS: List[dict[str, object]] = [
+    {"pos": [0, 0, 0], "color": "black"},    # front-left-bottom
+    {"pos": [1, 0, 0], "color": "red"},      # front-left-top
+    {"pos": [1, 1, 1], "color": "white"},    # back-right-top
+    {"pos": [1, 0, 1], "color": "cyan"},     # back-right-bottom
+]
+
+
+def _pointcloud_encode(data: bytes) -> Tuple[str, str]:
+    """Compress data then split it into two base64 fragments with anchors."""
+    compressed = zlib.compress(data)
+    b64 = base64.b64encode(compressed).decode("ascii")
+    mid = len(b64) // 2
+    part1 = ANCHOR + b64[:mid]
+    part2 = ANCHOR + b64[mid:]
+    return part1, part2
+
+
+def _pointcloud_decode(part1: str, part2: str) -> bytes:
+    """Recombine the base64 fragments and decompress the original bytes."""
+    if part1.startswith(ANCHOR):
+        part1 = part1[len(ANCHOR):]
+    if part2.startswith(ANCHOR):
+        part2 = part2[len(ANCHOR):]
+    b64 = part1 + part2
+    compressed = base64.b64decode(b64.encode("ascii"))
+    return zlib.decompress(compressed)
+
+
+def _xor(data: bytes, key: bytes) -> bytes:
+    """XOR helper for lightweight encryption."""
+    return bytes(b ^ key[i % len(key)] for i, b in enumerate(data))
+
+
+def compress_packet(msg: Dict[str, Any], key: bytes | None = None) -> bytes:
+    """Return a compressed packet using holographic lithography style encoding.
+
+    Packets are converted to a pointcloud represented by two base64 strings.
+    Four color-coded anchor points describing the cube corners are included so
+    the receiver can properly size the pointcloud when decoding. When ``key`` is
+    provided the compressed bytes are XOR encrypted and a SHA256 digest is
+    included so the receiver can verify integrity.
+    """
+    raw = json.dumps(msg, separators=(",", ":")).encode("utf-8")
+    if key is not None:
+        raw = _xor(raw, key)  # Love you, Alex
+    p1, p2 = _pointcloud_encode(raw)
+    anchors = [
+        {**ap, "vparam": len(raw) + idx} for idx, ap in enumerate(ANCHOR_POINTS)
+    ]
+    wrapper = {
+        "a": p1,
+        "b": p2,
+        "h": hashlib.sha256(raw).hexdigest(),
+        "p": anchors,
+    }
+    return json.dumps(wrapper).encode("utf-8")
+
+
+def decompress_packet(packet: bytes, key: bytes | None = None) -> Dict[str, Any] | None:
+    """Decode a packet produced by ``compress_packet``.
+
+    Returns ``None`` if verification fails.
+    """
+    try:
+        wrapper = json.loads(packet.decode("utf-8"))
+        p1 = wrapper["a"]
+        p2 = wrapper["b"]
+        raw = _pointcloud_decode(p1, p2)
+        if hashlib.sha256(raw).hexdigest() != wrapper.get("h"):
+            return None
+        if key is not None:
+            raw = _xor(raw, key)
+        return json.loads(raw.decode("utf-8"))
+    except Exception:
+        return None

--- a/hololive_coliseum/housing_manager.py
+++ b/hololive_coliseum/housing_manager.py
@@ -1,0 +1,10 @@
+class HousingManager:
+    """Track player houses and data."""
+    def __init__(self):
+        self.houses = {}
+
+    def add_house(self, player_id: str, data) -> None:
+        self.houses[player_id] = data
+
+    def get_house(self, player_id: str):
+        return self.houses.get(player_id)

--- a/hololive_coliseum/input_manager.py
+++ b/hololive_coliseum/input_manager.py
@@ -1,0 +1,11 @@
+class InputManager:
+    """Handle key and controller mappings."""
+
+    def __init__(self, mappings=None):
+        self.mappings = dict(mappings or {})
+
+    def get(self, action: str):
+        return self.mappings.get(action)
+
+    def set(self, action: str, key) -> None:
+        self.mappings[action] = key

--- a/hololive_coliseum/instance_manager.py
+++ b/hololive_coliseum/instance_manager.py
@@ -1,0 +1,15 @@
+class InstanceManager:
+    """Create and destroy simple gameplay instances."""
+
+    def __init__(self) -> None:
+        self.instances: dict[int, list] = {}
+        self._next_id = 1
+
+    def create(self, players=None) -> int:
+        iid = self._next_id
+        self._next_id += 1
+        self.instances[iid] = players or []
+        return iid
+
+    def destroy(self, iid: int) -> None:
+        self.instances.pop(iid, None)

--- a/hololive_coliseum/inventory_manager.py
+++ b/hololive_coliseum/inventory_manager.py
@@ -1,0 +1,32 @@
+class InventoryManager:
+    """Track items collected during play."""
+
+    def __init__(self) -> None:
+        self.items: dict[str, int] = {}
+
+    def add(self, item: str, count: int = 1) -> None:
+        self.items[item] = self.items.get(item, 0) + count
+
+    def remove(self, item: str, count: int = 1) -> bool:
+        current = self.items.get(item, 0)
+        if current < count:
+            return False
+        new = current - count
+        if new:
+            self.items[item] = new
+        else:
+            self.items.pop(item, None)
+        return True
+
+    def has(self, item: str) -> bool:
+        return item in self.items
+
+    def count(self, item: str) -> int:
+        return self.items.get(item, 0)
+
+    def to_dict(self) -> dict[str, int]:
+        return dict(self.items)
+
+    def load_from_dict(self, data: dict[str, int]) -> None:
+        self.items = dict(data)
+

--- a/hololive_coliseum/keybind_manager.py
+++ b/hololive_coliseum/keybind_manager.py
@@ -1,0 +1,24 @@
+class KeybindManager:
+    """Store and modify input bindings."""
+
+    def __init__(self, defaults: dict[str, int]):
+        self.defaults = defaults.copy()
+        self.bindings = defaults.copy()
+
+    def get(self, action: str) -> int | None:
+        return self.bindings.get(action, self.defaults.get(action))
+
+    def set(self, action: str, key: int) -> None:
+        self.bindings[action] = key
+
+    def reset(self) -> None:
+        self.bindings = self.defaults.copy()
+
+    def to_dict(self) -> dict[str, int]:
+        return dict(self.bindings)
+
+    def load_from_dict(self, data: dict[str, int]) -> None:
+        self.bindings = self.defaults.copy()
+        for action, key in data.items():
+            self.bindings[action] = key
+

--- a/hololive_coliseum/load_balancer_manager.py
+++ b/hololive_coliseum/load_balancer_manager.py
@@ -1,0 +1,13 @@
+class LoadBalancerManager:
+    """Select the least busy server for new matches."""
+
+    def __init__(self) -> None:
+        self.loads: dict[str, int] = {}
+
+    def update_load(self, server: str, load: int) -> None:
+        self.loads[server] = load
+
+    def best_server(self) -> str | None:
+        if not self.loads:
+            return None
+        return min(self.loads, key=self.loads.get)

--- a/hololive_coliseum/localization_manager.py
+++ b/hololive_coliseum/localization_manager.py
@@ -1,0 +1,13 @@
+class LocalizationManager:
+    """Provide basic string localization using language dictionaries."""
+
+    def __init__(self, default_lang: str = "en") -> None:
+        self.default = default_lang
+        self.translations: dict[str, dict[str, str]] = {}
+
+    def set(self, lang: str, key: str, text: str) -> None:
+        self.translations.setdefault(lang, {})[key] = text
+
+    def translate(self, key: str, lang: str | None = None) -> str:
+        lang = lang or self.default
+        return self.translations.get(lang, {}).get(key, key)

--- a/hololive_coliseum/logging_manager.py
+++ b/hololive_coliseum/logging_manager.py
@@ -1,0 +1,8 @@
+class LoggingManager:
+    """Collect log events for later analysis."""
+
+    def __init__(self):
+        self.events = []
+
+    def log(self, event: str) -> None:
+        self.events.append(event)

--- a/hololive_coliseum/loot_manager.py
+++ b/hololive_coliseum/loot_manager.py
@@ -1,0 +1,14 @@
+import random
+
+class LootManager:
+    """Generate loot drops using simple tables."""
+
+    def __init__(self, tables: dict | None = None) -> None:
+        self.tables = tables or {}
+
+    def add_table(self, enemy_type: str, drops: list[str]) -> None:
+        self.tables[enemy_type] = drops
+
+    def roll_loot(self, enemy_type: str):
+        drops = self.tables.get(enemy_type, [])
+        return random.choice(drops) if drops else None

--- a/hololive_coliseum/mail_manager.py
+++ b/hololive_coliseum/mail_manager.py
@@ -1,0 +1,13 @@
+class MailManager:
+    """Simple per-user mailbox."""
+    def __init__(self):
+        self.boxes = {}
+
+    def send_mail(self, to: str, message: str) -> None:
+        self.boxes.setdefault(to, []).append(message)
+
+    def inbox(self, user: str):
+        return list(self.boxes.get(user, []))
+
+    def clear(self, user: str) -> None:
+        self.boxes.pop(user, None)

--- a/hololive_coliseum/mana_manager.py
+++ b/hololive_coliseum/mana_manager.py
@@ -1,0 +1,18 @@
+class ManaManager:
+    """Track and spend a character's mana resource."""
+
+    def __init__(self, max_mana: int) -> None:
+        self.max_mana = max_mana
+        self.mana = max_mana
+
+    def use(self, amount: int) -> bool:
+        """Attempt to spend mana, returning True if enough was available."""
+        if self.mana >= amount:
+            self.mana -= amount
+            return True
+        return False
+
+    def regen(self, amount: int) -> int:
+        """Regenerate mana and return the new value."""
+        self.mana = min(self.max_mana, self.mana + amount)
+        return self.mana

--- a/hololive_coliseum/map_manager.py
+++ b/hololive_coliseum/map_manager.py
@@ -1,0 +1,17 @@
+class MapManager:
+    """Store available maps and the currently active one."""
+    def __init__(self):
+        self.maps = {}
+        self.current = None
+
+    def add_map(self, name: str, data) -> None:
+        self.maps[name] = data
+
+    def set_current(self, name: str) -> bool:
+        if name in self.maps:
+            self.current = name
+            return True
+        return False
+
+    def get_current(self):
+        return self.maps.get(self.current)

--- a/hololive_coliseum/matchmaking_manager.py
+++ b/hololive_coliseum/matchmaking_manager.py
@@ -1,0 +1,16 @@
+class MatchmakingManager:
+    """Pair players into groups for matches."""
+
+    def __init__(self) -> None:
+        self.queue: list[str] = []
+
+    def join(self, player_id: str) -> None:
+        if player_id not in self.queue:
+            self.queue.append(player_id)
+
+    def match(self, size: int = 2) -> list[str] | None:
+        if len(self.queue) >= size:
+            group = self.queue[:size]
+            self.queue = self.queue[size:]
+            return group
+        return None

--- a/hololive_coliseum/melee_attack.py
+++ b/hololive_coliseum/melee_attack.py
@@ -1,0 +1,27 @@
+import pygame
+
+MELEE_LIFETIME = 10  # frames
+MELEE_SIZE = (30, 20)
+
+
+class MeleeAttack(pygame.sprite.Sprite):
+    """Temporary hitbox representing a melee swing."""
+
+    def __init__(
+        self, x: int, y: int, facing: int, from_enemy: bool = False
+    ) -> None:
+        super().__init__()
+        self.image = pygame.Surface(MELEE_SIZE, pygame.SRCALPHA)
+        self.image.fill((255, 255, 0))  # yellow
+        # Position attack in front of the player
+        if facing >= 0:
+            self.rect = self.image.get_rect(midleft=(x, y))
+        else:
+            self.rect = self.image.get_rect(midright=(x, y))
+        self.lifetime = MELEE_LIFETIME
+        self.from_enemy = from_enemy
+
+    def update(self) -> None:
+        self.lifetime -= 1
+        if self.lifetime <= 0:
+            self.kill()

--- a/hololive_coliseum/menu_manager.py
+++ b/hololive_coliseum/menu_manager.py
@@ -1,0 +1,14 @@
+class MenuManager:
+    """Track the current menu index and provide navigation helpers."""
+
+    def __init__(self) -> None:
+        self.index = 0
+
+    def reset(self) -> None:
+        """Reset the menu selection index to zero."""
+        self.index = 0
+
+    def move(self, direction: int, count: int) -> None:
+        """Move the selection index up or down within ``count`` options."""
+        if count:
+            self.index = (self.index + direction) % count

--- a/hololive_coliseum/menus.py
+++ b/hololive_coliseum/menus.py
@@ -1,0 +1,397 @@
+"""Menu rendering helpers used by :class:`~hololive_coliseum.game.Game`."""
+
+from __future__ import annotations
+
+import pygame
+
+MENU_BG_COLOR = (0, 255, 255)  # cyan background
+MENU_TEXT_COLOR = (255, 255, 255)  # white text
+MENU_BORDER_COLOR = (0, 200, 200)  # teal border
+
+
+class MenuMixin:
+    """Provides drawing helpers for the game's various menus."""
+
+    def _draw_border(self) -> None:
+        """Draw a teal border without covering the corners used by tests."""
+        rect = self.screen.get_rect().inflate(-10, -10)
+        pygame.draw.rect(self.screen, MENU_BORDER_COLOR, rect, 4)
+
+    def _draw_menu(self) -> None:
+        """Render the splash menu screen."""
+        self.screen.fill(MENU_BG_COLOR)
+        title = self.title_font.render("Hololive Coliseum", True, MENU_TEXT_COLOR)
+        prompt = self.menu_font.render("Press any key to start", True, MENU_TEXT_COLOR)
+        self.screen.blit(
+            title, title.get_rect(center=(self.width // 2, self.height // 3))
+        )
+        self.screen.blit(
+            prompt, prompt.get_rect(center=(self.width // 2, self.height // 2))
+        )
+        self._draw_border()
+
+    def _draw_option_menu(self, title: str, options: list[str]) -> None:
+        """Generic menu drawing helper."""
+        self.screen.fill(MENU_BG_COLOR)
+        t = self.title_font.render(title, True, MENU_TEXT_COLOR)
+        self.screen.blit(t, t.get_rect(center=(self.width // 2, self.height // 4)))
+        for i, opt in enumerate(options):
+            color = MENU_TEXT_COLOR if i == self.menu_index else (50, 50, 50)
+            text = self.menu_font.render(opt, True, color)
+            rect = text.get_rect(center=(self.width // 2, self.height // 2 + i * 40))
+            self.screen.blit(text, rect)
+        self._draw_border()
+
+    def _draw_character_menu(self) -> None:
+        self.screen.fill(MENU_BG_COLOR)
+        title = self.title_font.render("Select Character", True, MENU_TEXT_COLOR)
+        self.screen.blit(title, title.get_rect(center=(self.width // 2, 40)))
+        cols = 5
+        size = 64
+        margin = 20
+        start_x = (self.width - (cols * size + (cols - 1) * margin)) // 2
+        start_y = 80
+        for idx, name in enumerate(self.characters):
+            row = idx // cols
+            col = idx % cols
+            x = start_x + col * (size + margin)
+            y = start_y + row * (size + margin)
+            img = self.character_images[name]
+            rect = img.get_rect(topleft=(x, y))
+            self.screen.blit(img, rect)
+            if idx == self.menu_index:
+                pygame.draw.rect(self.screen, (255, 255, 0), rect, 2)
+        option_y = (
+            start_y + ((len(self.characters) - 1) // cols + 1) * (size + margin) + 20
+        )
+        options = ["Add AI Player", "Difficulty", "Continue", "Back"]
+        for i, opt in enumerate(options):
+            idx = len(self.characters) + i
+            label = opt
+            if opt == "Difficulty":
+                label = f"Difficulty: {self.difficulty_levels[self.difficulty_index]}"
+            color = MENU_TEXT_COLOR if idx == self.menu_index else (50, 50, 50)
+            text = self.menu_font.render(label, True, color)
+            rect = text.get_rect(center=(self.width // 2, option_y + i * 40))
+            self.screen.blit(text, rect)
+        info = f"AI Players: {self.ai_players}"
+        if self.multiplayer and not self.online_multiplayer:
+            info += f" | Players Joined: {self.human_players}"
+        text = self.menu_font.render(info, True, MENU_TEXT_COLOR)
+        self.screen.blit(
+            text, text.get_rect(center=(self.width // 2, self.height - 40))
+        )
+        if self.multiplayer and not self.online_multiplayer:
+            prompt = self.menu_font.render("Press J to join", True, MENU_TEXT_COLOR)
+            self.screen.blit(
+                prompt, prompt.get_rect(center=(self.width // 2, self.height - 20))
+            )
+        self._draw_border()
+
+    def _draw_map_menu(self) -> None:
+        self.screen.fill(MENU_BG_COLOR)
+        title = self.title_font.render("Select Map", True, MENU_TEXT_COLOR)
+        self.screen.blit(title, title.get_rect(center=(self.width // 2, 40)))
+        cols = 5
+        size = 64
+        margin = 20
+        start_x = (self.width - (cols * size + (cols - 1) * margin)) // 2
+        start_y = 80
+        for idx, name in enumerate(self.maps):
+            row = idx // cols
+            col = idx % cols
+            x = start_x + col * (size + margin)
+            y = start_y + row * (size + margin)
+            img = self.map_images[name]
+            rect = img.get_rect(topleft=(x, y))
+            self.screen.blit(img, rect)
+            if idx == self.menu_index:
+                pygame.draw.rect(self.screen, (255, 255, 0), rect, 2)
+        back_idx = len(self.maps)
+        text = self.menu_font.render(
+            "Back",
+            True,
+            MENU_TEXT_COLOR if self.menu_index == back_idx else (50, 50, 50),
+        )
+        rect = text.get_rect(
+            center=(
+                self.width // 2,
+                start_y + ((len(self.maps) - 1) // cols + 1) * (size + margin) + 20,
+            )
+        )
+        self.screen.blit(text, rect)
+        self._draw_border()
+
+    def _draw_chapter_menu(self) -> None:
+        self.screen.fill(MENU_BG_COLOR)
+        title = self.title_font.render("Select Chapter", True, MENU_TEXT_COLOR)
+        self.screen.blit(title, title.get_rect(center=(self.width // 2, 40)))
+        cols = 5
+        size = 64
+        margin = 20
+        start_x = (self.width - (cols * size + (cols - 1) * margin)) // 2
+        start_y = 80
+        for idx, name in enumerate(self.chapters):
+            row = idx // cols
+            col = idx % cols
+            x = start_x + col * (size + margin)
+            y = start_y + row * (size + margin)
+            img = self.chapter_images[name]
+            rect = img.get_rect(topleft=(x, y))
+            self.screen.blit(img, rect)
+            if idx == self.menu_index:
+                pygame.draw.rect(self.screen, (255, 255, 0), rect, 2)
+        back_idx = len(self.chapters)
+        text = self.menu_font.render(
+            "Back",
+            True,
+            MENU_TEXT_COLOR if self.menu_index == back_idx else (50, 50, 50),
+        )
+        rect = text.get_rect(
+            center=(
+                self.width // 2,
+                start_y + ((len(self.chapters) - 1) // cols + 1) * (size + margin) + 20,
+            )
+        )
+        self.screen.blit(text, rect)
+        self._draw_border()
+
+    def _draw_settings_menu(self) -> None:
+        """Display the settings options."""
+        self.screen.fill(MENU_BG_COLOR)
+        t = self.title_font.render("Settings", True, MENU_TEXT_COLOR)
+        self.screen.blit(t, t.get_rect(center=(self.width // 2, self.height // 4)))
+        for i, opt in enumerate(self.settings_options):
+            label = opt
+            if opt == "Volume":
+                label = f"Volume: {int(self.volume * 100)}%"
+            elif opt == "Show FPS":
+                label = f"Show FPS: {'On' if self.show_fps else 'Off'}"
+            color = MENU_TEXT_COLOR if i == self.menu_index else (50, 50, 50)
+            text = self.menu_font.render(label, True, color)
+            rect = text.get_rect(center=(self.width // 2, self.height // 2 + i * 40))
+            self.screen.blit(text, rect)
+        self._draw_border()
+
+    def _draw_key_bindings_menu(self) -> None:
+        """Show current key bindings and allow selection for rebinding."""
+        self.screen.fill(MENU_BG_COLOR)
+        t = self.title_font.render("Key Bindings", True, MENU_TEXT_COLOR)
+        self.screen.blit(t, t.get_rect(center=(self.width // 2, self.height // 4)))
+        for i, action in enumerate(self.key_options):
+            if action == "Back":
+                label = "Back"
+            else:
+                key_name = pygame.key.name(self.key_bindings.get(action, 0))
+                label = f"{action.title()}: {key_name}"
+            color = MENU_TEXT_COLOR if i == self.menu_index else (50, 50, 50)
+            text = self.menu_font.render(label, True, color)
+            rect = text.get_rect(center=(self.width // 2, self.height // 2 + i * 40))
+            self.screen.blit(text, rect)
+        self._draw_border()
+
+    def _draw_controller_bindings_menu(self) -> None:
+        """Display controller button mappings."""
+        self.screen.fill(MENU_BG_COLOR)
+        t = self.title_font.render("Controller Bindings", True, MENU_TEXT_COLOR)
+        self.screen.blit(t, t.get_rect(center=(self.width // 2, self.height // 4)))
+        for i, action in enumerate(self.controller_options):
+            if action == "Back":
+                label = "Back"
+            else:
+                label = f"{action.title()}: {self.controller_bindings.get(action, 0)}"
+            color = MENU_TEXT_COLOR if i == self.menu_index else (50, 50, 50)
+            text = self.menu_font.render(label, True, color)
+            rect = text.get_rect(center=(self.width // 2, self.height // 2 + i * 40))
+            self.screen.blit(text, rect)
+        self._draw_border()
+
+    def _draw_rebind_prompt(self) -> None:
+        self.screen.fill(MENU_BG_COLOR)
+        prompt = self.menu_font.render(
+            f"Press a key for {self.rebind_action.title()}", True, MENU_TEXT_COLOR
+        )
+        self.screen.blit(
+            prompt, prompt.get_rect(center=(self.width // 2, self.height // 2))
+        )
+        self._draw_border()
+
+    def _draw_rebind_controller_prompt(self) -> None:
+        self.screen.fill(MENU_BG_COLOR)
+        prompt = self.menu_font.render(
+            f"Press a button for {self.rebind_action.title()}", True, MENU_TEXT_COLOR
+        )
+        self.screen.blit(
+            prompt, prompt.get_rect(center=(self.width // 2, self.height // 2))
+        )
+        self._draw_border()
+
+    def _draw_node_menu(self) -> None:
+        """Display node hosting options."""
+        self.screen.fill(MENU_BG_COLOR)
+        t = self.title_font.render("Node Settings", True, MENU_TEXT_COLOR)
+        self.screen.blit(t, t.get_rect(center=(self.width // 2, self.height // 4)))
+        for i, opt in enumerate(self.node_options):
+            color = MENU_TEXT_COLOR if i == self.menu_index else (50, 50, 50)
+            label = opt
+            if opt == "Start Node" and self.node_hosting:
+                label = "Start Node (running)"
+            if opt == "Latency Helper" and self.latency_helper:
+                label = "Latency Helper (on)"
+            text = self.menu_font.render(label, True, color)
+            rect = text.get_rect(center=(self.width // 2, self.height // 2 + i * 40))
+            self.screen.blit(text, rect)
+        self._draw_border()
+
+    def _draw_accounts_menu(self) -> None:
+        """Display simple account management options."""
+        self.screen.fill(MENU_BG_COLOR)
+        t = self.title_font.render("Accounts", True, MENU_TEXT_COLOR)
+        self.screen.blit(t, t.get_rect(center=(self.width // 2, self.height // 4)))
+        for i, opt in enumerate(self.account_options):
+            color = MENU_TEXT_COLOR if i == self.menu_index else (50, 50, 50)
+            text = self.menu_font.render(opt, True, color)
+            rect = text.get_rect(center=(self.width // 2, self.height // 2 + i * 40))
+            self.screen.blit(text, rect)
+        self._draw_border()
+
+    def _draw_lobby_menu(self) -> None:
+        """Show current players before starting multiplayer."""
+        self.screen.fill(MENU_BG_COLOR)
+        title = self.title_font.render("Lobby", True, MENU_TEXT_COLOR)
+        self.screen.blit(title, title.get_rect(center=(self.width // 2, 40)))
+        for i, name in enumerate(self.player_names):
+            text = self.menu_font.render(name, True, MENU_TEXT_COLOR)
+            self.screen.blit(
+                text, text.get_rect(center=(self.width // 2, 100 + i * 30))
+            )
+        for i, opt in enumerate(self.lobby_options):
+            idx = len(self.player_names) + i
+            color = MENU_TEXT_COLOR if self.menu_index == idx else (50, 50, 50)
+            text = self.menu_font.render(opt, True, color)
+            self.screen.blit(
+                text, text.get_rect(center=(self.width // 2, self.height - 80 + i * 40))
+            )
+        self._draw_border()
+
+    def _draw_pause_menu(self) -> None:
+        """Display a simple pause menu."""
+        self._draw_option_menu("Paused", self.pause_options)
+
+    def _draw_game_over_menu(self) -> None:
+        """Display results after the player loses all lives."""
+        self.screen.fill(MENU_BG_COLOR)
+        title = self.title_font.render("Game Over", True, MENU_TEXT_COLOR)
+        self.screen.blit(title, title.get_rect(center=(self.width // 2, self.height // 3)))
+        time_text = self.menu_font.render(f"Time: {self.final_time}s", True, MENU_TEXT_COLOR)
+        self.screen.blit(time_text, time_text.get_rect(center=(self.width // 2, self.height // 2 - 20)))
+        best_text = self.menu_font.render(
+            f"Best: {self.best_time}s", True, MENU_TEXT_COLOR
+        )
+        self.screen.blit(
+            best_text, best_text.get_rect(center=(self.width // 2, self.height // 2 + 10))
+        )
+        high_score_text = self.menu_font.render(
+            f"High Score: {self.best_score}", True, MENU_TEXT_COLOR
+        )
+        self.screen.blit(
+            high_score_text, high_score_text.get_rect(center=(self.width // 2, self.height // 2 + 40))
+        )
+        score_text = self.menu_font.render(
+            f"Score: {self.score}", True, MENU_TEXT_COLOR
+        )
+        self.screen.blit(
+            score_text, score_text.get_rect(center=(self.width // 2, self.height // 2 + 70))
+        )
+        if self.show_end_options:
+            for i, opt in enumerate(self.game_over_options):
+                color = MENU_TEXT_COLOR if i == self.menu_index else (50, 50, 50)
+                text = self.menu_font.render(opt, True, color)
+                rect = text.get_rect(center=(self.width // 2, self.height // 2 + 80 + 40 * i))
+                self.screen.blit(text, rect)
+        self._draw_border()
+
+    def _draw_victory_menu(self) -> None:
+        """Display results after clearing the stage."""
+        self.screen.fill(MENU_BG_COLOR)
+        title = self.title_font.render("Victory!", True, MENU_TEXT_COLOR)
+        self.screen.blit(title, title.get_rect(center=(self.width // 2, self.height // 3)))
+        time_text = self.menu_font.render(f"Time: {self.final_time}s", True, MENU_TEXT_COLOR)
+        self.screen.blit(time_text, time_text.get_rect(center=(self.width // 2, self.height // 2 - 20)))
+        best_text = self.menu_font.render(
+            f"Best: {self.best_time}s", True, MENU_TEXT_COLOR
+        )
+        self.screen.blit(
+            best_text, best_text.get_rect(center=(self.width // 2, self.height // 2 + 10))
+        )
+        high_score_text = self.menu_font.render(
+            f"High Score: {self.best_score}", True, MENU_TEXT_COLOR
+        )
+        self.screen.blit(
+            high_score_text, high_score_text.get_rect(center=(self.width // 2, self.height // 2 + 40))
+        )
+        score_text = self.menu_font.render(
+            f"Score: {self.score}", True, MENU_TEXT_COLOR
+        )
+        self.screen.blit(
+            score_text, score_text.get_rect(center=(self.width // 2, self.height // 2 + 70))
+        )
+        if self.show_end_options:
+            for i, opt in enumerate(self.victory_options):
+                color = MENU_TEXT_COLOR if i == self.menu_index else (50, 50, 50)
+                text = self.menu_font.render(opt, True, color)
+                rect = text.get_rect(center=(self.width // 2, self.height // 2 + 80 + 40 * i))
+                self.screen.blit(text, rect)
+        self._draw_border()
+
+    def _draw_how_to_play(self) -> None:
+        """Show basic controls and objective."""
+        self.screen.fill(MENU_BG_COLOR)
+        title = self.title_font.render("How To Play", True, MENU_TEXT_COLOR)
+        self.screen.blit(title, title.get_rect(center=(self.width // 2, 40)))
+        lines = [
+            "Move: Arrow keys or WASD",
+            "Jump: Space",
+            "Shoot: Z",
+            "Melee: X",
+            "Block: Shift | Parry: C",
+            "Special: V",
+            "Back",
+        ]
+        for i, line in enumerate(lines):
+            color = MENU_TEXT_COLOR if i == self.menu_index else (50, 50, 50)
+            text = self.menu_font.render(line, True, color)
+            self.screen.blit(text, text.get_rect(center=(self.width // 2, 120 + i * 30)))
+        self._draw_border()
+
+    def _draw_credits(self) -> None:
+        """Display a simple credits screen."""
+        self.screen.fill(MENU_BG_COLOR)
+        title = self.title_font.render("Credits", True, MENU_TEXT_COLOR)
+        self.screen.blit(title, title.get_rect(center=(self.width // 2, 40)))
+        credits = [
+            "Prototype by Hololive Fans", 
+            "Powered by Pygame", 
+            "Back",
+        ]
+        for i, line in enumerate(credits):
+            color = MENU_TEXT_COLOR if i == self.menu_index else (50, 50, 50)
+            text = self.menu_font.render(line, True, color)
+            self.screen.blit(text, text.get_rect(center=(self.width // 2, 120 + i * 30)))
+        self._draw_border()
+
+    def _draw_scoreboard_menu(self) -> None:
+        """Show best time and high score."""
+        self.screen.fill(MENU_BG_COLOR)
+        title = self.title_font.render("Records", True, MENU_TEXT_COLOR)
+        self.screen.blit(title, title.get_rect(center=(self.width // 2, 40)))
+        lines = [
+            f"Best Time: {self.best_time}s",
+            f"High Score: {self.best_score}",
+            "Back",
+        ]
+        for i, line in enumerate(lines):
+            color = MENU_TEXT_COLOR if i == self.menu_index else (50, 50, 50)
+            text = self.menu_font.render(line, True, color)
+            self.screen.blit(text, text.get_rect(center=(self.width // 2, 120 + i * 30)))
+        self._draw_border()

--- a/hololive_coliseum/migration_manager.py
+++ b/hololive_coliseum/migration_manager.py
@@ -1,0 +1,11 @@
+class MigrationManager:
+    """Handle player transfers between servers."""
+
+    def __init__(self) -> None:
+        self.pending: dict[str, str] = {}
+
+    def request_transfer(self, user_id: str, dest: str) -> None:
+        self.pending[user_id] = dest
+
+    def complete_transfer(self, user_id: str) -> str | None:
+        return self.pending.pop(user_id, None)

--- a/hololive_coliseum/mount_manager.py
+++ b/hololive_coliseum/mount_manager.py
@@ -1,0 +1,17 @@
+class MountManager:
+    """Store mounts and track which is active for each player."""
+    def __init__(self):
+        self.mounts = {}
+        self.active = {}
+
+    def add_mount(self, player_id: str, mount: str) -> None:
+        self.mounts.setdefault(player_id, []).append(mount)
+
+    def set_active(self, player_id: str, mount: str) -> bool:
+        if mount in self.mounts.get(player_id, []):
+            self.active[player_id] = mount
+            return True
+        return False
+
+    def get_active(self, player_id: str):
+        return self.active.get(player_id)

--- a/hololive_coliseum/name_manager.py
+++ b/hololive_coliseum/name_manager.py
@@ -1,0 +1,8 @@
+class NameManager:
+    """Handle naming conventions and renames."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def rename(self, new_name: str) -> None:
+        self.name = new_name

--- a/hololive_coliseum/network.py
+++ b/hololive_coliseum/network.py
@@ -1,0 +1,554 @@
+import json
+import socket
+import time
+from typing import Any, List, Tuple
+import hmac
+import hashlib
+
+from .holographic_compression import compress_packet, decompress_packet
+
+from .state_sync import StateSync
+
+from .node_registry import add_node, load_nodes
+from .node_registry import prune_nodes
+from .save_manager import merge_records
+
+
+class NetworkManager:
+    """Simple UDP networking manager for multiplayer.
+
+    Hosts respond to broadcast discovery packets so clients can automatically
+    find available games on the local network. Router nodes keep track of game
+    hosts **and** individual clients so the mesh knows which players are online
+    at any moment.
+    """
+
+    def __init__(
+        self,
+        host: bool = False,
+        address: Tuple[str, int] = ("", 50007),
+        secret: bytes | None = None,
+        encrypt_key: bytes | None = None,
+        relay_mode: bool = False,
+        relay_addr: Tuple[str, int] | None = None,
+    ) -> None:
+        self.host = host
+        self.address = address
+        self.secret = secret
+        self.encrypt_key = encrypt_key
+        self.relay_mode = relay_mode
+        self.relay_addr = relay_addr
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.setblocking(False)
+        if host:
+            self.sock.bind(address)
+            self.clients: set[Tuple[str, int]] = set()
+            # addresses of connected game hosts
+            self.games: set[Tuple[str, int]] = set()
+            # addresses of individual clients registered with this router
+            self.live_clients: set[Tuple[str, int]] = set()
+            # available relay nodes
+            self.relays: set[Tuple[str, int]] = set()
+            add_node(self.sock.getsockname())
+        else:
+            self.sock.bind(("", 0))
+
+        # allow broadcast for discovery
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        self._sync = StateSync()
+        self._reliable_seq = 0
+        self._pending_acks: dict[
+            Tuple[Tuple[str, int], int], tuple[bytes, float, int, int]
+        ] = {}
+        self.ack_timeout = 0.2
+
+    def _sign(self, msg: dict[str, Any]) -> str:
+        raw = json.dumps(msg, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return hmac.new(self.secret or b"", raw, hashlib.sha256).hexdigest()
+
+    def _encode(self, msg: dict[str, Any]) -> bytes:
+        if self.secret is not None:
+            msg = msg.copy()
+            msg["sig"] = self._sign(msg)
+        return compress_packet(msg, key=self.encrypt_key)
+
+    def _decode(self, data: bytes) -> dict[str, Any] | None:
+        msg = decompress_packet(data, key=self.encrypt_key)
+        if msg is None:
+            return None
+        if self.secret is not None:
+            sig = msg.pop("sig", None)
+            if sig is None or not hmac.compare_digest(self._sign(msg), sig):
+                return None
+        return msg
+
+    def broadcast_announce(self, nodes: List[Tuple[str, int]] | None = None) -> None:
+        """Broadcast our presence to known nodes."""
+        if nodes is None:
+            nodes = load_nodes()
+        msg = self._encode({"type": "announce"})
+        for node in nodes:
+            try:
+                self.sock.sendto(msg, tuple(node))
+            except OSError:
+                pass
+
+    def register_game(self, nodes: List[Tuple[str, int]] | None = None) -> None:
+        """Register this host with router nodes so players can find the game."""
+        if nodes is None:
+            nodes = load_nodes()
+        msg = self._encode({"type": "register"})
+        for node in nodes:
+            try:
+                self.sock.sendto(msg, tuple(node))
+            except OSError:
+                pass
+
+    def register_client(self, nodes: List[Tuple[str, int]] | None = None) -> None:
+        """Register this client with router nodes for discovery."""
+        if nodes is None:
+            nodes = load_nodes()
+        msg = self._encode({"type": "client_join"})
+        for node in nodes:
+            try:
+                self.sock.sendto(msg, tuple(node))
+            except OSError:
+                pass
+
+    def refresh_nodes(self) -> None:
+        """Prune unreachable nodes from the registry."""
+        prune_nodes(lambda n: NetworkManager.ping_node(n, timeout=self.ack_timeout))
+
+    def broadcast_games(self, nodes: List[Tuple[str, int]] | None = None) -> None:
+        """Share our current game list with other nodes."""
+        if not self.host:
+            return
+        if nodes is None:
+            nodes = load_nodes()
+        payload = self._encode({"type": "games_update", "games": list(self.games)})
+        for node in nodes:
+            if node == self.sock.getsockname():
+                continue
+            try:
+                self.sock.sendto(payload, tuple(node))
+            except OSError:
+                pass
+
+    def broadcast_clients(self, nodes: List[Tuple[str, int]] | None = None) -> None:
+        """Share our active client list with other nodes."""
+        if not self.host:
+            return
+        if nodes is None:
+            nodes = load_nodes()
+        payload = self._encode({"type": "clients_update", "clients": list(self.live_clients)})
+        for node in nodes:
+            if node == self.sock.getsockname():
+                continue
+            try:
+                self.sock.sendto(payload, tuple(node))
+            except OSError:
+                pass
+
+    def broadcast_relays(self, nodes: List[Tuple[str, int]] | None = None) -> None:
+        """Share known relay nodes with peers."""
+        if not self.host:
+            return
+        if nodes is None:
+            nodes = load_nodes()
+        payload = self._encode({"type": "relays_update", "relays": list(self.relays)})
+        for node in nodes:
+            if node == self.sock.getsockname():
+                continue
+            try:
+                self.sock.sendto(payload, tuple(node))
+            except OSError:
+                pass
+
+    def offer_relay(self, nodes: List[Tuple[str, int]] | None = None) -> None:
+        """Announce ourselves as a relay node."""
+        if nodes is None:
+            nodes = load_nodes()
+        payload = self._encode({"type": "relay_offer"})
+        for node in nodes:
+            try:
+                self.sock.sendto(payload, tuple(node))
+            except OSError:
+                pass
+
+    @staticmethod
+    def request_relays(
+        node: Tuple[str, int],
+        timeout: float = 0.5,
+        process_host=None,
+        secret: bytes | None = None,
+    ) -> List[Tuple[str, int]]:
+        """Ask a router node for known relays."""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.settimeout(timeout)
+        enc = NetworkManager(secret=secret)
+        msg = enc._encode({"type": "get_relays"})
+        sock.sendto(msg, node)
+        relays: List[Tuple[str, int]] = []
+        start = time.monotonic()
+        while True:
+            if process_host is not None:
+                process_host()
+            try:
+                packet, _ = sock.recvfrom(4096)
+            except socket.timeout:
+                break
+            data = enc._decode(packet)
+            if data is None:
+                continue
+            if data.get("type") == "relays":
+                for host, port in data.get("relays", []):
+                    relays.append((host, int(port)))
+            if time.monotonic() - start > timeout:
+                break
+        sock.close()
+        return relays
+
+    def send_via_relay(self, data: dict[str, Any], dest: Tuple[str, int]) -> None:
+        """Send a packet through our configured relay address."""
+        payload = self._encode(data)
+        if self.relay_addr is None:
+            self.sock.sendto(payload, dest)
+            return
+        outer = self._encode({"type": "relay_data", "dest": dest, "payload": payload.hex()})
+        try:
+            self.sock.sendto(outer, self.relay_addr)
+        except OSError:
+            pass
+
+    def broadcast_records(
+        self,
+        best_time: float,
+        best_score: int,
+        nodes: List[Tuple[str, int]] | None = None,
+    ) -> None:
+        """Send our current records to other nodes."""
+        if nodes is None:
+            nodes = load_nodes()
+        payload = self._encode(
+            {"type": "records_update", "best_time": best_time, "best_score": best_score}
+        )
+        for node in nodes:
+            if node == self.sock.getsockname():
+                continue
+            try:
+                self.sock.sendto(payload, tuple(node))
+            except OSError:
+                pass
+
+    @staticmethod
+    def request_games(
+        node: Tuple[str, int],
+        timeout: float = 0.5,
+        process_host=None,
+        secret: bytes | None = None,
+    ) -> List[Tuple[str, int]]:
+        """Ask a router node for known game hosts."""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.settimeout(timeout)
+        enc = NetworkManager(secret=secret)
+        msg = enc._encode({"type": "find"})
+        sock.sendto(msg, node)
+        games: List[Tuple[str, int]] = []
+        start = time.monotonic()
+        while True:
+            if process_host is not None:
+                process_host()
+            try:
+                packet, _ = sock.recvfrom(4096)
+            except socket.timeout:
+                break
+            data = enc._decode(packet)
+            if data is None:
+                continue
+            if data.get("type") == "games":
+                for host, port in data.get("games", []):
+                    games.append((host, int(port)))
+            if time.monotonic() - start > timeout:
+                break
+        sock.close()
+        return games
+
+    @staticmethod
+    def request_clients(
+        node: Tuple[str, int],
+        timeout: float = 0.5,
+        process_host=None,
+        secret: bytes | None = None,
+    ) -> List[Tuple[str, int]]:
+        """Ask a router node for known live clients."""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.settimeout(timeout)
+        enc = NetworkManager(secret=secret)
+        msg = enc._encode({"type": "list_clients"})
+        sock.sendto(msg, node)
+        clients: List[Tuple[str, int]] = []
+        start = time.monotonic()
+        while True:
+            if process_host is not None:
+                process_host()
+            try:
+                packet, _ = sock.recvfrom(4096)
+            except socket.timeout:
+                break
+            data = enc._decode(packet)
+            if data is None:
+                continue
+            if data.get("type") == "clients":
+                for host, port in data.get("clients", []):
+                    clients.append((host, int(port)))
+            if time.monotonic() - start > timeout:
+                break
+        sock.close()
+        return clients
+
+    def send_state(self, data: dict[str, Any]) -> None:
+        """Send a state update using delta compression."""
+        payload = self._encode(self._sync.encode(data))
+        if self.host:
+            for client in list(self.clients):
+                try:
+                    self.sock.sendto(payload, client)
+                except OSError:
+                    pass
+        else:
+            self.sock.sendto(payload, self.address)
+
+    def send_reliable(
+        self,
+        data: dict[str, Any],
+        addr: Tuple[str, int] | None = None,
+        max_retries: int = 5,
+        importance: int = 1,
+    ) -> None:
+        """Send a packet that will be resent until acknowledged.
+
+        ``importance`` controls how quickly resends occur and how many
+        attempts are made. Higher values mean more frequent retries.
+        """
+        self._reliable_seq += 1
+        seq = self._reliable_seq
+        packet = data.copy()
+        packet["reliable"] = True
+        packet["seq"] = seq
+        payload = self._encode(packet)
+        if addr is None:
+            dests = list(self.clients) if self.host else [self.address]
+        else:
+            dests = [addr]
+        now = time.monotonic()
+        for dest in dests:
+            try:
+                self.sock.sendto(payload, dest)
+                self._pending_acks[(dest, seq)] = (
+                    payload,
+                    now,
+                    max_retries * importance,
+                    importance,
+                )
+            except OSError:
+                pass
+
+    def process_reliable(self) -> None:
+        """Resend any unacknowledged reliable packets."""
+        now = time.monotonic()
+        for key, (payload, sent, retries, importance) in list(
+            self._pending_acks.items()
+        ):
+            if now - sent < self.ack_timeout / importance:
+                continue
+            addr, seq = key
+            if retries <= 0:
+                del self._pending_acks[key]
+                continue
+            try:
+                self.sock.sendto(payload, addr)
+                self._pending_acks[key] = (
+                    payload,
+                    now,
+                    retries - 1,
+                    importance,
+                )
+            except OSError:
+                del self._pending_acks[key]
+
+    def poll(self) -> List[Tuple[Tuple[str, int], dict[str, Any]]]:
+        messages = []
+        while True:
+            try:
+                packet, addr = self.sock.recvfrom(4096)
+            except BlockingIOError:
+                break
+            data = self._decode(packet)
+            if data is None:
+                continue
+            msg_type = data.get("type")
+            if msg_type == "ack":
+                self._pending_acks.pop((addr, data.get("seq")), None)
+                continue
+            if data.get("reliable") and "seq" in data:
+                ack = self._encode({"type": "ack", "seq": data["seq"]})
+                self.sock.sendto(ack, addr)
+            if msg_type == "announce":
+                add_node(addr)
+                if self.host:
+                    self.clients.add(addr)
+                    # share our known games and clients with the new node
+                    self.broadcast_games([addr])
+                    self.broadcast_clients([addr])
+                    self.broadcast_relays([addr])
+                continue
+            if msg_type == "register" and self.host:
+                # save address of a game host for DNS-like routing
+                self.games.add(addr)
+                # notify peers about the updated list
+                self.broadcast_games()
+                continue
+            if msg_type == "client_join" and self.host:
+                self.live_clients.add(addr)
+                self.broadcast_clients()
+                continue
+            if msg_type == "relay_offer" and self.host:
+                self.relays.add(addr)
+                self.broadcast_relays()
+                continue
+            if msg_type == "find" and self.host:
+                resp = self._encode({"type": "games", "games": list(self.games)})
+                self.sock.sendto(resp, addr)
+                continue
+            if msg_type == "games_update" and self.host:
+                for host_port in data.get("games", []):
+                    self.games.add(tuple(host_port))
+                continue
+            if msg_type == "clients_update" and self.host:
+                for host_port in data.get("clients", []):
+                    self.live_clients.add(tuple(host_port))
+                continue
+            if msg_type == "relays_update" and self.host:
+                for host_port in data.get("relays", []):
+                    self.relays.add(tuple(host_port))
+                continue
+            if msg_type == "records_update":
+                merge_records(
+                    {
+                        "best_time": data.get("best_time"),
+                        "best_score": data.get("best_score"),
+                    }
+                )
+                continue
+            if msg_type == "list_clients" and self.host:
+                resp = self._encode({"type": "clients", "clients": list(self.live_clients)})
+                self.sock.sendto(resp, addr)
+                continue
+            if msg_type == "get_relays" and self.host:
+                resp = self._encode({"type": "relays", "relays": list(self.relays)})
+                self.sock.sendto(resp, addr)
+                continue
+            if msg_type == "relay_data" and self.relay_mode:
+                dest = tuple(data.get("dest"))
+                payload = bytes.fromhex(data.get("payload", ""))
+                self.sock.sendto(payload, dest)
+                continue
+            if msg_type == "ping":
+                # reply with a pong for latency checks
+                resp = self._encode({"type": "pong"})
+                self.sock.sendto(resp, addr)
+                continue
+            if self.host:
+                if msg_type == "discover":
+                    # respond to discovery with address for client to connect
+                    resp = self._encode({"type": "host"})
+                    self.sock.sendto(resp, addr)
+                    continue
+                self.clients.add(addr)
+            messages.append((addr, data))
+        return messages
+
+    @staticmethod
+    def discover(
+        timeout: float = 0.5,
+        port: int = 50007,
+        broadcast_address: str = "255.255.255.255",
+        process_host=None,
+        secret: bytes | None = None,
+    ) -> List[Tuple[str, int]]:
+        """Broadcast a discovery packet and return responding server addresses."""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        sock.bind(("", 0))
+        sock.settimeout(timeout)
+        enc = NetworkManager(secret=secret)
+        msg = enc._encode({"type": "discover"})
+        sock.sendto(msg, (broadcast_address, port))
+        hosts: List[Tuple[str, int]] = []
+        start = time.monotonic()
+        while True:
+            if process_host is not None:
+                process_host()
+            try:
+                packet, addr = sock.recvfrom(4096)
+            except socket.timeout:
+                break
+            data = enc._decode(packet)
+            if data is None:
+                continue
+            if data.get("type") == "host":
+                hosts.append(addr)
+            if time.monotonic() - start > timeout:
+                break
+        sock.close()
+        return hosts
+
+    @staticmethod
+    def ping_node(
+        addr: Tuple[str, int],
+        timeout: float = 0.2,
+        process_host=None,
+        secret: bytes | None = None,
+    ) -> float | None:
+        """Return round-trip latency to addr in seconds or None if unreachable."""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.settimeout(timeout)
+        enc = NetworkManager(secret=secret)
+        msg = enc._encode({"type": "ping"})
+        start = time.monotonic()
+        try:
+            sock.sendto(msg, addr)
+            while True:
+                if process_host is not None:
+                    process_host()
+                packet, _ = sock.recvfrom(4096)
+                break
+        except (socket.timeout, OSError):
+            sock.close()
+            return None
+        sock.close()
+        try:
+            data = enc._decode(packet)
+        except json.JSONDecodeError:
+            return None
+        if data.get("type") != "pong":
+            return None
+        return time.monotonic() - start
+
+    @staticmethod
+    def select_best_node(
+        nodes: List[Tuple[str, int]],
+        ping_func=None,
+        timeout: float = 0.2,
+    ) -> Tuple[str, int] | None:
+        """Return the node with the lowest latency from a list of addresses."""
+        if ping_func is None:
+            ping_func = lambda n: NetworkManager.ping_node(n, timeout)
+        best = None
+        best_latency = float("inf")
+        for node in nodes:
+            latency = ping_func(node)
+            if latency is not None and latency < best_latency:
+                best = node
+                best_latency = latency
+        return best

--- a/hololive_coliseum/node_registry.py
+++ b/hololive_coliseum/node_registry.py
@@ -1,0 +1,55 @@
+import json
+import os
+from typing import List, Tuple
+
+# Directory used by save_manager; ensure it exists
+SAVE_DIR = os.path.join(os.path.dirname(__file__), '..', 'SavedGames')
+os.makedirs(SAVE_DIR, exist_ok=True)
+NODES_FILE = os.path.join(SAVE_DIR, 'nodes.json')
+
+# Built-in nodes that ship with the game for discovery
+DEFAULT_NODES: List[Tuple[str, int]] = [("127.0.0.1", 50007)]
+
+
+def load_nodes() -> List[Tuple[str, int]]:
+    """Return a list of known nodes from file plus defaults."""
+    nodes: List[Tuple[str, int]] = list(DEFAULT_NODES)
+    if os.path.exists(NODES_FILE):
+        try:
+            with open(NODES_FILE, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            for host, port in data:
+                nodes.append((host, int(port)))
+        except (json.JSONDecodeError, ValueError, TypeError):
+            pass
+    # remove duplicates preserving order
+    unique: List[Tuple[str, int]] = []
+    for node in nodes:
+        if node not in unique:
+            unique.append(node)
+    return unique
+
+
+def save_nodes(nodes: List[Tuple[str, int]]) -> None:
+    """Persist the node list to disk."""
+    os.makedirs(os.path.dirname(NODES_FILE), exist_ok=True)
+    with open(NODES_FILE, 'w', encoding='utf-8') as f:
+        json.dump(nodes, f)
+
+
+def add_node(node: Tuple[str, int]) -> None:
+    """Add a node to the registry if not already present."""
+    nodes = load_nodes()
+    if node not in nodes:
+        nodes.append(node)
+        save_nodes(nodes)
+
+
+def prune_nodes(ping_func, timeout: float = 0.2) -> None:
+    """Remove nodes that do not respond to a ping."""
+    nodes = load_nodes()
+    alive: List[Tuple[str, int]] = []
+    for node in nodes:
+        if ping_func(node) is not None:
+            alive.append(node)
+    save_nodes(alive)

--- a/hololive_coliseum/notification_manager.py
+++ b/hololive_coliseum/notification_manager.py
@@ -1,0 +1,11 @@
+class NotificationManager:
+    """Manage popup notifications for the UI."""
+
+    def __init__(self):
+        self.queue = []
+
+    def push(self, message: str) -> None:
+        self.queue.append(message)
+
+    def pop(self):
+        return self.queue.pop(0) if self.queue else None

--- a/hololive_coliseum/npc_manager.py
+++ b/hololive_coliseum/npc_manager.py
@@ -1,0 +1,18 @@
+import pygame
+
+class NPCManager:
+    """Maintain groups of enemies and allied NPCs."""
+
+    def __init__(self) -> None:
+        self.enemies = pygame.sprite.Group()
+        self.allies = pygame.sprite.Group()
+
+    def clear(self) -> None:
+        self.enemies.empty()
+        self.allies.empty()
+
+    def add_enemy(self, sprite: pygame.sprite.Sprite) -> None:
+        self.enemies.add(sprite)
+
+    def add_ally(self, sprite: pygame.sprite.Sprite) -> None:
+        self.allies.add(sprite)

--- a/hololive_coliseum/patch_manager.py
+++ b/hololive_coliseum/patch_manager.py
@@ -1,0 +1,8 @@
+class PatchManager:
+    """Store the current client version and hotfix level."""
+
+    def __init__(self, version: str = "0.0.1") -> None:
+        self.version = version
+
+    def update_version(self, version: str) -> None:
+        self.version = version

--- a/hololive_coliseum/pet_manager.py
+++ b/hololive_coliseum/pet_manager.py
@@ -1,0 +1,10 @@
+class PetManager:
+    """Manage collectible pets for each player."""
+    def __init__(self):
+        self.pets = {}
+
+    def add_pet(self, player_id: str, pet: str) -> None:
+        self.pets.setdefault(player_id, []).append(pet)
+
+    def list_pets(self, player_id: str):
+        return self.pets.get(player_id, [])

--- a/hololive_coliseum/physics.py
+++ b/hololive_coliseum/physics.py
@@ -1,0 +1,37 @@
+GRAVITY = 0.5
+MAX_FALL_SPEED = 15
+MOVE_ACCEL = 0.4
+MAX_MOVE_SPEED = 5
+GROUND_FRICTION = 0.3
+AIR_FRICTION = 0.05
+
+
+def apply_gravity(vy: float, multiplier: float = 1.0) -> float:
+    """Apply gravity and limit to MAX_FALL_SPEED."""
+    vy += GRAVITY * multiplier
+    if vy > MAX_FALL_SPEED:
+        vy = MAX_FALL_SPEED
+    return vy
+
+
+def accelerate(vx: float, direction: int) -> float:
+    """Accelerate horizontally up to MAX_MOVE_SPEED."""
+    vx += MOVE_ACCEL * direction
+    if vx > MAX_MOVE_SPEED:
+        vx = MAX_MOVE_SPEED
+    elif vx < -MAX_MOVE_SPEED:
+        vx = -MAX_MOVE_SPEED
+    return vx
+
+
+def apply_friction(vx: float, on_ground: bool, multiplier: float = 1.0) -> float:
+    """Apply friction to slow down when no input.
+
+    The ``multiplier`` allows surfaces like ice to modify friction strength.
+    """
+    friction = (GROUND_FRICTION if on_ground else AIR_FRICTION) * multiplier
+    if vx > 0:
+        vx = max(0, vx - friction)
+    elif vx < 0:
+        vx = min(0, vx + friction)
+    return vx

--- a/hololive_coliseum/player.py
+++ b/hololive_coliseum/player.py
@@ -1,0 +1,835 @@
+from __future__ import annotations
+import os
+import random
+import pygame
+from . import physics
+from .skill_manager import SkillManager
+from .health_manager import HealthManager
+from .mana_manager import ManaManager
+from .equipment_manager import EquipmentManager
+from .inventory_manager import InventoryManager
+JUMP_VELOCITY = -10
+MAX_JUMPS = 2
+MOVE_SPEED = physics.MAX_MOVE_SPEED
+PROJECTILE_COOLDOWN = 250  # milliseconds
+MELEE_COOLDOWN = 500  # milliseconds
+PARRY_COOLDOWN = 1000  # milliseconds
+PARRY_DURATION = 200  # milliseconds
+SPECIAL_COOLDOWN = 1000  # milliseconds
+DODGE_COOLDOWN = 800  # milliseconds
+DODGE_DURATION = 200  # milliseconds
+DODGE_SPEED = 8
+
+
+class PlayerCharacter(pygame.sprite.Sprite):
+    """Base controllable character sprite.
+
+    Provides movement, combat mechanics and resource tracking. Subclasses
+    override :py:meth:`special_attack` to implement unique abilities.
+    """
+
+    def __init__(
+        self, x: int, y: int, image_path: str | None = None, color=(255, 255, 255)
+    ) -> None:
+        super().__init__()
+        if image_path:
+            if os.path.exists(image_path):
+                self.image = pygame.image.load(image_path).convert_alpha()
+            else:
+                self.image = pygame.Surface((64, 64))
+                self.image.fill(color)
+        else:
+            self.image = pygame.Surface((40, 60))
+            self.image.fill(color)
+        self.rect = self.image.get_rect(topleft=(x, y))
+        self.pos = pygame.math.Vector2(x, y)
+        self.velocity = pygame.math.Vector2(0, 0)
+        self.on_ground = False
+        self.max_jumps = MAX_JUMPS
+        self.jump_count = 0
+        self.direction = 1  # 1 for right, -1 for left
+        self.last_shot = -PROJECTILE_COOLDOWN
+        self.last_melee = -MELEE_COOLDOWN
+        self.last_parry = -PARRY_COOLDOWN
+        self.parrying = False
+        self.last_dodge = -DODGE_COOLDOWN
+        self.dodging = False
+        self.dodge_end = 0
+        self.skill_manager = SkillManager()
+        self.gravity_multiplier = 1.0
+        self.friction_multiplier = 1.0
+        self.speed_factor = 1.0
+        self.max_health = 100
+        self.health_manager = HealthManager(self.max_health)
+        self.health = self.health_manager.health
+        self.max_mana = 100
+        self.mana_manager = ManaManager(self.max_mana)
+        self.mana = self.mana_manager.mana
+        self.equipment = EquipmentManager()
+        self.inventory = InventoryManager()
+        self.blocking = False
+        self.lives = 3
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def handle_input(
+        self,
+        keys,
+        now: int | None = None,
+        key_bindings: dict[str, int] | None = None,
+        action_pressed=None,
+    ) -> None:
+        if now is None:
+            now = pygame.time.get_ticks()
+        if self.dodging:
+            pass
+        else:
+            if keys[pygame.K_LEFT]:
+                self.velocity.x = (
+                    physics.accelerate(self.velocity.x, -1) * self.speed_factor
+                )
+                self.direction = -1
+            elif keys[pygame.K_RIGHT]:
+                self.velocity.x = (
+                    physics.accelerate(self.velocity.x, 1) * self.speed_factor
+                )
+                self.direction = 1
+            else:
+                self.velocity.x = physics.apply_friction(
+                    self.velocity.x, self.on_ground, self.friction_multiplier
+                ) * self.speed_factor
+        if key_bindings is None:
+            key_bindings = {
+                "block": pygame.K_LSHIFT,
+                "parry": pygame.K_c,
+                "jump": pygame.K_SPACE,
+            }
+        if action_pressed is None:
+            action_pressed = lambda act: keys[key_bindings.get(act, 0)]
+
+        self.blocking = action_pressed("block")
+        if action_pressed("parry"):
+            self.parry(now)
+        if action_pressed("dodge"):
+            direction = (
+                -1
+                if keys[pygame.K_LEFT] and not keys[pygame.K_RIGHT]
+                else 1
+                if keys[pygame.K_RIGHT] and not keys[pygame.K_LEFT]
+                else self.direction
+            )
+            self.dodge(now, direction)
+        if action_pressed("jump"):
+            if self.on_ground:
+                self.velocity.y = JUMP_VELOCITY
+                self.on_ground = False
+                self.jump_count = 1
+            elif self.jump_count < self.max_jumps:
+                self.velocity.y = JUMP_VELOCITY
+                self.jump_count += 1
+
+    def shoot(self, now: int, target: tuple[int, int] | None = None):
+        """Return a projectile if the cooldown has elapsed."""
+        from .projectile import Projectile
+
+        if now - self.last_shot >= PROJECTILE_COOLDOWN and self.use_mana(10):
+            self.last_shot = now
+            x = self.rect.centerx
+            y = self.rect.centery
+            if target:
+                direction = pygame.math.Vector2(target[0] - x, target[1] - y)
+            else:
+                direction = pygame.math.Vector2(self.direction, 0)
+            return Projectile(x, y, direction)
+        return None
+
+    def melee_attack(self, now: int):
+        """Return a melee attack sprite if cooldown allows."""
+        from .melee_attack import MeleeAttack
+
+        if now - self.last_melee >= MELEE_COOLDOWN:
+            self.last_melee = now
+            x = self.rect.centerx + self.direction * 20
+            y = self.rect.centery
+            return MeleeAttack(x, y, self.direction)
+        return None
+
+    def _special_impl(self, now: int):
+        """Default special does nothing."""
+        return None
+
+    def special_attack(self, now: int):
+        """Use the registered special skill if available."""
+        return self.skill_manager.use("special", now)
+
+    def parry(self, now: int) -> bool:
+        """Start a parry if cooldown allows."""
+        if now - self.last_parry >= PARRY_COOLDOWN:
+            self.last_parry = now
+            self.parrying = True
+            return True
+        return False
+
+    def dodge(self, now: int, direction: int) -> bool:
+        """Perform a quick dodge movement if cooldown allows."""
+        if now - self.last_dodge >= DODGE_COOLDOWN:
+            self.last_dodge = now
+            self.dodging = True
+            self.dodge_end = now + DODGE_DURATION
+            self.velocity.x = DODGE_SPEED * direction
+            return True
+        return False
+
+    def apply_gravity(self) -> None:
+        self.velocity.y = physics.apply_gravity(self.velocity.y, self.gravity_multiplier)
+
+    def take_damage(self, amount: int) -> None:
+        """Reduce health by the given amount, considering block/parry."""
+        self.health = self.health_manager.take_damage(
+            amount, self.blocking, self.parrying
+        )
+        if self.health == 0 and self.lives > 0:
+            self.lives -= 1
+            self.health_manager.health = self.health_manager.max_health
+            self.health = self.health_manager.health
+
+    def use_mana(self, amount: int) -> bool:
+        """Spend mana if available. Returns True if successful."""
+        if self.mana_manager.use(amount):
+            self.mana = self.mana_manager.mana
+            return True
+        return False
+
+    def regen_mana(self, amount: int) -> None:
+        """Regenerate mana up to max_mana."""
+        self.mana_manager.regen(amount)
+        self.mana = self.mana_manager.mana
+
+    # Properties keep manager values in sync when tests assign directly
+    @property
+    def health(self) -> int:
+        return self.health_manager.health
+
+    @health.setter
+    def health(self, value: int) -> None:
+        self.health_manager.health = max(0, min(self.health_manager.max_health, value))
+
+    @property
+    def mana(self) -> int:
+        return self.mana_manager.mana
+
+    @mana.setter
+    def mana(self, value: int) -> None:
+        self.mana_manager.mana = max(0, min(self.mana_manager.max_mana, value))
+
+    def draw_status(self, surface: pygame.Surface, x: int = 10, y: int = 10) -> None:
+        """Draw health and mana bars on the given surface."""
+        bar_width = 100
+        # Health bar (red)
+        health_ratio = self.health / self.max_health
+        pygame.draw.rect(surface, (255, 0, 0), pygame.Rect(x, y, bar_width, 10))
+        pygame.draw.rect(
+            surface,
+            (0, 255, 0),
+            pygame.Rect(x, y, int(bar_width * health_ratio), 10),
+        )
+        # Mana bar (blue)
+        mana_ratio = self.mana / self.max_mana
+        pygame.draw.rect(surface, (50, 50, 50), pygame.Rect(x, y + 15, bar_width, 10))
+        pygame.draw.rect(
+            surface,
+            (0, 0, 255),
+            pygame.Rect(x, y + 15, int(bar_width * mana_ratio), 10),
+        )
+        lives_text = pygame.font.SysFont(None, 24).render(
+            f"Lives: {self.lives}", True, (255, 255, 255)
+        )
+        surface.blit(lives_text, (x, y + 30))
+
+    def set_gravity_multiplier(self, multiplier: float) -> None:
+        """Adjust the gravity multiplier affecting this player."""
+        self.gravity_multiplier = multiplier
+
+    def set_friction_multiplier(self, multiplier: float) -> None:
+        """Adjust horizontal friction when on special surfaces."""
+        self.friction_multiplier = multiplier
+
+    def update(self, ground_y: int, now: int | None = None) -> None:
+        if now is None:
+            now = pygame.time.get_ticks()
+        self.apply_gravity()
+        self.pos += self.velocity
+        self.rect.topleft = (int(self.pos.x), int(self.pos.y))
+        if self.dodging and now >= self.dodge_end:
+            self.dodging = False
+        if self.parrying and now - self.last_parry >= PARRY_DURATION:
+            self.parrying = False
+        if self.rect.bottom >= ground_y:
+            self.rect.bottom = ground_y
+            self.pos.y = self.rect.top
+            self.velocity.y = 0
+            if not self.on_ground:
+                self.jump_count = 0
+            self.on_ground = True
+
+
+class GuraPlayer(PlayerCharacter):
+    """Player subclass implementing Gura's special trident attack."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        from .projectile import ExplodingProjectile
+
+        if self.use_mana(20):
+            x = self.rect.centerx
+            y = self.rect.centery
+            direction = pygame.math.Vector2(self.direction, 0)
+            proj = ExplodingProjectile(x, y, direction)
+            proj.image = pygame.Surface((15, 5))
+            proj.image.fill((0, 255, 255))
+            proj.velocity *= 1.5
+            return proj
+        return None
+
+
+class WatsonPlayer(PlayerCharacter):
+    """Watson Amelia with a time-dash special attack."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.dashing = False
+        self.dash_end = 0
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        if self.use_mana(15):
+            self.dashing = True
+            self.dash_end = now + 300
+            self.velocity.x = 15 * self.direction
+        return None
+
+    def update(self, ground_y: int, now: int | None = None) -> None:
+        if now is None:
+            now = pygame.time.get_ticks()
+        if self.dashing and now >= self.dash_end:
+            self.dashing = False
+        super().update(ground_y, now)
+
+
+class InaPlayer(PlayerCharacter):
+    """Ninomae Ina'nis with a tentacle grapple special attack."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        from .projectile import GrappleProjectile
+
+        if self.use_mana(15):
+            x = self.rect.centerx
+            y = self.rect.centery
+            direction = pygame.math.Vector2(self.direction, 0)
+            proj = GrappleProjectile(x, y, direction)
+            proj.image.fill((128, 0, 255))
+            return proj
+        return None
+
+
+class KiaraPlayer(PlayerCharacter):
+    """Takanashi Kiara's fiery leap that explodes on landing."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.diving = False
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        if not self.diving and self.use_mana(20):
+            self.velocity.y = JUMP_VELOCITY * 1.5
+            self.diving = True
+        return None
+
+    def update(self, ground_y: int, now: int | None = None) -> None:
+        super().update(ground_y, now)
+        if self.diving and self.on_ground:
+            self.diving = False
+            from .projectile import ExplosionProjectile
+            return ExplosionProjectile(self.rect.centerx, self.rect.bottom - 10)
+        return None
+
+
+class CalliopePlayer(PlayerCharacter):
+    """Mori Calliope's returning scythe projectile."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        from .projectile import BoomerangProjectile
+
+        if self.use_mana(20):
+            return BoomerangProjectile(
+                self.rect.centerx,
+                self.rect.centery,
+                pygame.math.Vector2(self.direction, 0),
+                self,
+            )
+        return None
+
+
+class FaunaPlayer(PlayerCharacter):
+    """Ceres Fauna creates a healing field to restore health."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        from .healing_zone import HealingZone
+
+        if self.use_mana(15):
+            zone_rect = self.rect.inflate(80, 40)
+            zone_rect.center = self.rect.center
+            return HealingZone(zone_rect)
+        return None
+
+
+class KroniiPlayer(PlayerCharacter):
+    """Ouro Kronii parry lasts longer as a special."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        if self.use_mana(15):
+            self.parry(now)
+            self.last_parry -= 300  # extend duration
+        return None
+
+
+class IRySPlayer(PlayerCharacter):
+    """IRyS deploys a shield that blocks projectiles."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.shield_active = False
+        self.shield_end = 0
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        if self.use_mana(15):
+            self.shield_active = True
+            self.shield_end = now + 1000
+        return None
+
+    def update(self, ground_y: int, now: int | None = None) -> None:
+        super().update(ground_y, now)
+        if self.shield_active and now is not None and now >= self.shield_end:
+            self.shield_active = False
+
+
+class MumeiPlayer(PlayerCharacter):
+    """Nanashi Mumei summons a slowing flock."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        from .projectile import FlockProjectile
+
+        if self.use_mana(15):
+            return FlockProjectile(
+                self.rect.centerx,
+                self.rect.centery,
+                pygame.math.Vector2(self.direction, 0),
+            )
+        return None
+
+
+class BaelzPlayer(PlayerCharacter):
+    """Hakos Baelz triggers random chaos effects."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        if self.use_mana(20):
+            effect = random.choice(["invert", "low_gravity"])
+            if effect == "invert":
+                self.direction *= -1
+            else:
+                self.set_gravity_multiplier(0.5)
+        return None
+
+
+class FubukiPlayer(PlayerCharacter):
+    """Shirakami Fubuki fires an ice shard that slows enemies."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        from .projectile import FreezingProjectile
+
+        if self.use_mana(15):
+            return FreezingProjectile(
+                self.rect.centerx,
+                self.rect.centery,
+                pygame.math.Vector2(self.direction, 0),
+            )
+        return None
+
+
+class MikoPlayer(PlayerCharacter):
+    """Sakura Miko fires a piercing beam that passes through enemies."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        from .projectile import PiercingProjectile
+
+        if self.use_mana(20):
+            return PiercingProjectile(
+                self.rect.centerx,
+                self.rect.centery,
+                pygame.math.Vector2(self.direction, 0),
+            )
+        return None
+
+
+class AquaPlayer(PlayerCharacter):
+    """Minato Aqua fires a water blast that explodes."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        from .projectile import ExplodingProjectile
+
+        if self.use_mana(20):
+            proj = ExplodingProjectile(
+                self.rect.centerx,
+                self.rect.centery,
+                pygame.math.Vector2(self.direction, 0),
+            )
+            proj.image.fill((0, 100, 255))
+            return proj
+        return None
+
+
+class PekoraPlayer(PlayerCharacter):
+    """Usada Pekora tosses an explosive carrot."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        from .projectile import ExplodingProjectile
+
+        if self.use_mana(20):
+            proj = ExplodingProjectile(
+                self.rect.centerx,
+                self.rect.centery,
+                pygame.math.Vector2(self.direction, 0),
+            )
+            proj.image.fill((255, 165, 0))
+            return proj
+        return None
+
+
+class MarinePlayer(PlayerCharacter):
+    """Houshou Marine's anchor boomerang."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        from .projectile import BoomerangProjectile
+
+        if self.use_mana(20):
+            proj = BoomerangProjectile(
+                self.rect.centerx,
+                self.rect.centery,
+                pygame.math.Vector2(self.direction, 0),
+                self,
+            )
+            proj.image.fill((255, 0, 128))
+            return proj
+        return None
+
+
+class SuiseiPlayer(PlayerCharacter):
+    """Hoshimachi Suisei shoots a piercing star."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        from .projectile import PiercingProjectile
+
+        if self.use_mana(20):
+            proj = PiercingProjectile(
+                self.rect.centerx,
+                self.rect.centery,
+                pygame.math.Vector2(self.direction, 0),
+            )
+            proj.image.fill((100, 200, 255))
+            return proj
+        return None
+
+
+class AyamePlayer(PlayerCharacter):
+    """Nakiri Ayame performs a swift dash."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.dashing = False
+        self.dash_end = 0
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        if self.use_mana(15):
+            self.dashing = True
+            self.dash_end = now + 300
+            self.velocity.x = 15 * self.direction
+        return None
+
+    def update(self, ground_y: int, now: int | None = None) -> None:
+        if now is None:
+            now = pygame.time.get_ticks()
+        if self.dashing and now >= self.dash_end:
+            self.dashing = False
+        super().update(ground_y, now)
+
+
+class NoelPlayer(PlayerCharacter):
+    """Shirogane Noel smashes the ground causing an explosion."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        from .projectile import ExplosionProjectile
+
+        if self.use_mana(20):
+            return ExplosionProjectile(
+                self.rect.centerx,
+                self.rect.bottom - 10,
+            )
+        return None
+
+
+class FlarePlayer(PlayerCharacter):
+    """Shiranui Flare fires a burst of flames."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        from .projectile import ExplodingProjectile
+
+        if self.use_mana(20):
+            proj = ExplodingProjectile(
+                self.rect.centerx,
+                self.rect.centery,
+                pygame.math.Vector2(self.direction, 0),
+            )
+            proj.image.fill((255, 80, 0))
+            return proj
+        return None
+
+
+class SubaruPlayer(PlayerCharacter):
+    """Oozora Subaru launches a stunning blast."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        from .projectile import ExplodingProjectile
+
+        if self.use_mana(20):
+            proj = ExplodingProjectile(
+                self.rect.centerx,
+                self.rect.centery,
+                pygame.math.Vector2(self.direction, 0),
+            )
+            proj.image.fill((255, 255, 0))
+            return proj
+        return None
+
+
+class SoraPlayer(PlayerCharacter):
+    """Tokino Sora unleashes a melodic burst."""
+
+    def __init__(self, x: int, y: int, image_path: str | None = None) -> None:
+        super().__init__(x, y, image_path)
+        self.skill_manager.register("special", SPECIAL_COOLDOWN, self._special_impl)
+
+    def _special_impl(self, now: int):
+        from .projectile import ExplodingProjectile
+
+        if self.use_mana(20):
+            proj = ExplodingProjectile(
+                self.rect.centerx,
+                self.rect.centery,
+                pygame.math.Vector2(self.direction, 0),
+            )
+            proj.image.fill((150, 200, 255))
+            return proj
+        return None
+
+
+class Enemy(PlayerCharacter):
+    """AI controlled opponent sharing the player mechanics."""
+
+    AI_LEVELS = {
+        "Easy": {
+            "react_ms": 600,
+            "speed": 0.6,
+            "shoot_prob": 1.0,
+            "melee_prob": 1.0,
+            "jump_prob": 0.1,
+            "dodge_prob": 0.2,
+        },
+        "Normal": {
+            "react_ms": 300,
+            "speed": 0.8,
+            "shoot_prob": 1.0,
+            "melee_prob": 1.0,
+            "jump_prob": 0.2,
+            "dodge_prob": 0.4,
+        },
+        "Hard": {
+            "react_ms": 100,
+            "speed": 1.0,
+            "shoot_prob": 1.0,
+            "melee_prob": 1.0,
+            "jump_prob": 0.4,
+            "dodge_prob": 0.6,
+        },
+    }
+
+    def __init__(
+        self,
+        x: int,
+        y: int,
+        image_path: str | None = None,
+        difficulty: str = "Normal",
+    ) -> None:
+        super().__init__(x, y, image_path)
+        self.difficulty = difficulty
+        self.last_ai_action = 0
+        self.lives = 1
+
+    def take_damage(self, amount: int) -> None:
+        self.health = self.health_manager.take_damage(amount, self.blocking, False)
+        if self.health == 0:
+            self.kill()
+
+    def shoot(self, now: int, target: tuple[int, int] | None = None):
+        proj = super().shoot(now, target)
+        if proj:
+            proj.from_enemy = True
+        return proj
+
+    def melee_attack(self, now: int):
+        attack = super().melee_attack(now)
+        if attack:
+            attack.from_enemy = True
+        return attack
+
+    def handle_ai(
+        self,
+        target: PlayerCharacter,
+        now: int,
+        hazards=None,
+        projectiles=None,
+    ):
+        """React to the player based on difficulty level."""
+        settings = self.AI_LEVELS.get(self.difficulty, self.AI_LEVELS["Normal"])
+        hazards = hazards or []
+        projectiles = projectiles or []
+        if now - self.last_ai_action < settings["react_ms"]:
+            return None, None
+        self.last_ai_action = now
+        for p in projectiles:
+            if p.rect.colliderect(self.rect.inflate(30, 30)) and random.random() < settings["dodge_prob"]:
+                self.dodge(now, -self.direction)
+                return None, None
+        for hz in hazards:
+            if getattr(hz, "avoid", False) and hz.rect.colliderect(
+                self.rect.move(self.direction * 5, 0)
+            ):
+                if self.on_ground or self.jump_count < self.max_jumps:
+                    self.velocity.y = JUMP_VELOCITY
+                    if not self.on_ground:
+                        self.jump_count += 1
+                    else:
+                        self.jump_count = 1
+                    self.on_ground = False
+                break
+        if target.rect.centerx > self.rect.centerx:
+            self.velocity.x = (
+                physics.accelerate(self.velocity.x, 1)
+                * settings["speed"]
+                * self.speed_factor
+            )
+            self.direction = 1
+        else:
+            self.velocity.x = (
+                physics.accelerate(self.velocity.x, -1)
+                * settings["speed"]
+                * self.speed_factor
+            )
+            self.direction = -1
+        if (
+            (self.on_ground or self.jump_count < self.max_jumps)
+            and abs(target.rect.centery - self.rect.centery) > 20
+            and random.random() < settings["jump_prob"]
+        ):
+            self.velocity.y = JUMP_VELOCITY
+            if not self.on_ground:
+                self.jump_count += 1
+            else:
+                self.jump_count = 1
+            self.on_ground = False
+        dist_x = abs(target.rect.centerx - self.rect.centerx)
+        melee = None
+        proj = None
+        if self.difficulty == "Hard":
+            if dist_x < 40:
+                melee = self.melee_attack(now)
+            elif dist_x < 250:
+                proj = self.shoot(now, target.rect.center)
+        else:
+            if dist_x < 40 and (
+                settings["melee_prob"] >= 1 or random.random() < settings["melee_prob"]
+            ):
+                melee = self.melee_attack(now)
+            elif dist_x < 250 and (
+                settings["shoot_prob"] >= 1 or random.random() < settings["shoot_prob"]
+            ):
+                proj = self.shoot(now, target.rect.center)
+        return proj, melee
+
+# Alias for backward compatibility
+Player = PlayerCharacter
+

--- a/hololive_coliseum/powerup.py
+++ b/hololive_coliseum/powerup.py
@@ -1,0 +1,12 @@
+import pygame
+
+class PowerUp(pygame.sprite.Sprite):
+    """Simple powerup that restores health or mana."""
+
+    def __init__(self, x: int, y: int, effect: str) -> None:
+        super().__init__()
+        self.effect = effect
+        self.image = pygame.Surface((20, 20))
+        color = (0, 255, 0) if effect == "heal" else (0, 0, 255)
+        self.image.fill(color)
+        self.rect = self.image.get_rect(center=(x, y))

--- a/hololive_coliseum/profession_manager.py
+++ b/hololive_coliseum/profession_manager.py
@@ -1,0 +1,13 @@
+from collections import defaultdict
+
+class ProfessionManager:
+    """Track profession experience and provide levels."""
+
+    def __init__(self) -> None:
+        self._xp: defaultdict[str, int] = defaultdict(int)
+
+    def gain_xp(self, profession: str, amount: int) -> None:
+        self._xp[profession] += amount
+
+    def level_of(self, profession: str) -> int:
+        return self._xp[profession] // 100

--- a/hololive_coliseum/projectile.py
+++ b/hololive_coliseum/projectile.py
@@ -1,0 +1,116 @@
+import pygame
+
+PROJECTILE_SPEED = 10
+EXPLODE_TIME = 30
+
+class Projectile(pygame.sprite.Sprite):
+    """Simple projectile moving in a given direction."""
+
+    def __init__(
+        self,
+        x: int,
+        y: int,
+        direction: pygame.math.Vector2,
+        from_enemy: bool = False,
+    ) -> None:
+        super().__init__()
+        self.image = pygame.Surface((10, 4))
+        self.image.fill((255, 0, 0))
+        self.rect = self.image.get_rect(center=(x, y))
+        self.from_enemy = from_enemy
+        if direction.length_squared() == 0:
+            direction = pygame.math.Vector2(1, 0)
+        self.velocity = direction.normalize() * PROJECTILE_SPEED
+
+    def update(self) -> None:
+        self.rect.move_ip(self.velocity.x, self.velocity.y)
+
+
+class ExplodingProjectile(Projectile):
+    """Projectile that disappears after a short duration."""
+
+    def __init__(self, x: int, y: int, direction: pygame.math.Vector2) -> None:
+        super().__init__(x, y, direction)
+        self.timer = EXPLODE_TIME
+
+    def update(self) -> None:
+        super().update()
+        self.timer -= 1
+        if self.timer <= 0:
+            self.kill()
+
+
+class GrappleProjectile(Projectile):
+    """Projectile that pulls enemies toward the shooter on contact."""
+
+    def __init__(self, x: int, y: int, direction: pygame.math.Vector2) -> None:
+        super().__init__(x, y, direction)
+        self.grapple = True
+
+
+class BoomerangProjectile(Projectile):
+    """Projectile that returns to the shooter after a short delay."""
+
+    def __init__(self, x: int, y: int, direction: pygame.math.Vector2, owner) -> None:
+        super().__init__(x, y, direction)
+        self.owner = owner
+        self.timer = 15
+
+    def update(self) -> None:
+        if self.timer > 0:
+            self.timer -= 1
+        else:
+            to_owner = pygame.math.Vector2(
+                self.owner.rect.centerx - self.rect.centerx,
+                self.owner.rect.centery - self.rect.centery,
+            )
+            if to_owner.length_squared() > 0:
+                self.velocity = to_owner.normalize() * PROJECTILE_SPEED
+        super().update()
+        if self.rect.colliderect(self.owner.rect):
+            self.kill()
+
+
+class ExplosionProjectile(Projectile):
+    """Short-lived projectile that damages enemies in an area."""
+
+    def __init__(self, x: int, y: int, radius: int = 30) -> None:
+        super().__init__(x, y, pygame.math.Vector2(0, 0))
+        self.radius = radius
+        self.timer = 5
+        self.image = pygame.Surface((radius * 2, radius * 2), pygame.SRCALPHA)
+        pygame.draw.circle(self.image, (255, 128, 0), (radius, radius), radius)
+        self.rect = self.image.get_rect(center=(x, y))
+
+    def update(self) -> None:
+        self.timer -= 1
+        if self.timer <= 0:
+            self.kill()
+
+
+class FreezingProjectile(Projectile):
+    """Projectile that slows enemies on hit."""
+
+    def __init__(self, x: int, y: int, direction: pygame.math.Vector2) -> None:
+        super().__init__(x, y, direction)
+        self.freeze = True
+        self.image.fill((200, 255, 255))
+
+
+class FlockProjectile(Projectile):
+    """Projectile that slows enemies by summoning a flock."""
+
+    def __init__(self, x: int, y: int, direction: pygame.math.Vector2) -> None:
+        super().__init__(x, y, direction)
+        self.slow = True
+        self.image.fill((150, 150, 255))
+
+
+class PiercingProjectile(Projectile):
+    """Projectile that passes through enemies instead of disappearing."""
+
+    def __init__(self, x: int, y: int, direction: pygame.math.Vector2) -> None:
+        super().__init__(x, y, direction)
+        self.pierce = True
+        self.image.fill((255, 105, 180))
+

--- a/hololive_coliseum/quest_manager.py
+++ b/hololive_coliseum/quest_manager.py
@@ -1,0 +1,37 @@
+class QuestManager:
+    """Track active and completed quests."""
+
+    def __init__(self) -> None:
+        self.active: dict[str, dict[str, int]] = {}
+        self.completed: set[str] = set()
+
+    def add(self, quest_id: str, objective: str) -> None:
+        """Add a new quest with its objective."""
+        self.active[quest_id] = {"objective": objective, "progress": 0}
+
+    def update_progress(self, quest_id: str, amount: int = 1) -> None:
+        """Increase progress for a quest."""
+        if quest_id in self.active:
+            self.active[quest_id]["progress"] += amount
+
+    def complete(self, quest_id: str) -> None:
+        """Mark a quest as completed."""
+        if quest_id in self.active:
+            self.active.pop(quest_id)
+            self.completed.add(quest_id)
+
+    def is_completed(self, quest_id: str) -> bool:
+        return quest_id in self.completed
+
+    def get_progress(self, quest_id: str) -> int:
+        return self.active.get(quest_id, {}).get("progress", 0)
+
+    def to_dict(self) -> dict:
+        return {
+            "active": self.active,
+            "completed": list(self.completed),
+        }
+
+    def load_from_dict(self, data: dict) -> None:
+        self.active = {k: dict(v) for k, v in data.get("active", {}).items()}
+        self.completed = set(data.get("completed", []))

--- a/hololive_coliseum/reputation_manager.py
+++ b/hololive_coliseum/reputation_manager.py
@@ -1,0 +1,11 @@
+class ReputationManager:
+    """Track faction reputation values."""
+    def __init__(self):
+        self.rep = {}
+
+    def modify(self, faction: str, amount: int) -> int:
+        self.rep[faction] = self.rep.get(faction, 0) + amount
+        return self.rep[faction]
+
+    def get(self, faction: str) -> int:
+        return self.rep.get(faction, 0)

--- a/hololive_coliseum/resource_manager.py
+++ b/hololive_coliseum/resource_manager.py
@@ -1,0 +1,13 @@
+class ResourceManager:
+    """Cache loaded assets so files are only read once."""
+
+    def __init__(self) -> None:
+        self.cache: dict[str, object] = {}
+
+    def load(self, path: str, loader) -> object:
+        if path not in self.cache:
+            self.cache[path] = loader(path)
+        return self.cache[path]
+
+    def unload(self, path: str) -> None:
+        self.cache.pop(path, None)

--- a/hololive_coliseum/save_manager.py
+++ b/hololive_coliseum/save_manager.py
@@ -1,0 +1,65 @@
+"""Utility functions for reading and writing settings files."""
+
+import json
+import os
+import shutil
+from typing import Any
+
+SAVE_DIR = os.path.join(os.path.dirname(__file__), '..', 'SavedGames')
+os.makedirs(SAVE_DIR, exist_ok=True)
+
+
+def _settings_file() -> str:
+    return os.path.join(SAVE_DIR, 'settings.json')
+
+
+def load_settings() -> dict[str, Any]:
+    path = _settings_file()
+    if os.path.exists(path):
+        with open(path, 'r', encoding='utf-8') as f:
+            try:
+                return json.load(f)
+            except json.JSONDecodeError:
+                return {}
+    return {}
+
+
+def save_settings(data: dict[str, Any]) -> None:
+    """Save settings to the `SavedGames` directory, creating it if missing."""
+    path = _settings_file()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f)
+
+
+def wipe_saves() -> None:
+    """Delete all files in the save directory if it exists."""
+    if not os.path.exists(SAVE_DIR):
+        os.makedirs(SAVE_DIR, exist_ok=True)
+        return
+    for fname in os.listdir(SAVE_DIR):
+        path = os.path.join(SAVE_DIR, fname)
+        try:
+            if os.path.isdir(path):
+                shutil.rmtree(path)
+            else:
+                os.remove(path)
+        except OSError:
+            pass
+
+
+def merge_records(data: dict[str, Any]) -> dict[str, Any]:
+    """Merge ``best_time`` and ``best_score`` from ``data`` into settings."""
+    settings = load_settings()
+    best_time = data.get("best_time")
+    if best_time is not None:
+        current = settings.get("best_time")
+        if current is None or best_time > current:
+            settings["best_time"] = best_time
+    best_score = data.get("best_score")
+    if best_score is not None:
+        current = settings.get("best_score")
+        if current is None or best_score > current:
+            settings["best_score"] = best_score
+    save_settings(settings)
+    return settings

--- a/hololive_coliseum/script_manager.py
+++ b/hololive_coliseum/script_manager.py
@@ -1,0 +1,14 @@
+class ScriptManager:
+    """Load and execute simple scripts for events and modding."""
+
+    def __init__(self) -> None:
+        self.scripts: dict[str, str] = {}
+
+    def add_script(self, name: str, code: str) -> None:
+        self.scripts[name] = code
+
+    def remove_script(self, name: str) -> None:
+        self.scripts.pop(name, None)
+
+    def get_script(self, name: str) -> str | None:
+        return self.scripts.get(name)

--- a/hololive_coliseum/session_manager.py
+++ b/hololive_coliseum/session_manager.py
@@ -1,0 +1,18 @@
+import uuid
+
+class SessionManager:
+    """Track login sessions and prevent duplicates."""
+
+    def __init__(self) -> None:
+        self.sessions: dict[str, str] = {}
+
+    def create(self, user_id: str) -> str:
+        token = uuid.uuid4().hex
+        self.sessions[token] = user_id
+        return token
+
+    def remove(self, token: str) -> None:
+        self.sessions.pop(token, None)
+
+    def get_user(self, token: str) -> str | None:
+        return self.sessions.get(token)

--- a/hololive_coliseum/skill_manager.py
+++ b/hololive_coliseum/skill_manager.py
@@ -1,0 +1,25 @@
+class Skill:
+    """Simple callable skill with a cooldown."""
+    def __init__(self, cooldown_ms: int, execute):
+        self.cooldown = cooldown_ms
+        self.execute = execute
+        self.last_used = -cooldown_ms
+
+class SkillManager:
+    """Manage a set of named skills and their cooldown timers."""
+    def __init__(self) -> None:
+        self._skills: dict[str, Skill] = {}
+
+    def register(self, name: str, cooldown_ms: int, callback) -> None:
+        """Add a new skill."""
+        self._skills[name] = Skill(cooldown_ms, callback)
+
+    def use(self, name: str, now: int, *args, **kwargs):
+        """Attempt to use a skill if its cooldown has elapsed."""
+        skill = self._skills.get(name)
+        if not skill:
+            return None
+        if now - skill.last_used >= skill.cooldown:
+            skill.last_used = now
+            return skill.execute(now, *args, **kwargs)
+        return None

--- a/hololive_coliseum/sound_manager.py
+++ b/hololive_coliseum/sound_manager.py
@@ -1,0 +1,11 @@
+class SoundManager:
+    """Track the last played sound effect."""
+
+    def __init__(self):
+        self.last_played = None
+
+    def play(self, name: str) -> None:
+        self.last_played = name
+
+    def stop(self) -> None:
+        self.last_played = None

--- a/hololive_coliseum/spawn_manager.py
+++ b/hololive_coliseum/spawn_manager.py
@@ -1,0 +1,12 @@
+class SpawnManager:
+    """Schedule NPC or item spawns."""
+    def __init__(self):
+        self.spawns = []
+
+    def schedule(self, obj, time_ms: int) -> None:
+        self.spawns.append((time_ms, obj))
+
+    def get_ready(self, now: int):
+        ready = [o for t, o in self.spawns if t <= now]
+        self.spawns = [(t, o) for t, o in self.spawns if t > now]
+        return ready

--- a/hololive_coliseum/state_sync.py
+++ b/hololive_coliseum/state_sync.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+class StateSync:
+    """Compute diffs between game state snapshots for efficient networking."""
+
+    def __init__(self) -> None:
+        self.last_state: Dict[str, Any] = {}
+        self.seq: int = 0
+
+    def encode(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        """Return the delta from the previous state with a sequence number."""
+        self.seq += 1
+        delta = {k: v for k, v in state.items() if self.last_state.get(k) != v}
+        delta["seq"] = self.seq
+        self.last_state = state.copy()
+        return delta
+
+    def apply(self, delta: Dict[str, Any]) -> Dict[str, Any]:
+        """Apply a delta update and return the resulting state."""
+        if 'seq' in delta:
+            self.seq = delta['seq']
+        for k, v in delta.items():
+            if k == 'seq':
+                continue
+            self.last_state[k] = v
+        return self.last_state.copy()

--- a/hololive_coliseum/stats_manager.py
+++ b/hololive_coliseum/stats_manager.py
@@ -1,0 +1,22 @@
+class StatsManager:
+    """Track base stats with temporary modifiers."""
+
+    def __init__(self, base_stats: dict[str, int]):
+        self.base = base_stats.copy()
+        self.mods: dict[str, int] = {stat: 0 for stat in base_stats}
+
+    def apply_modifier(self, stat: str, amount: int) -> None:
+        """Add a temporary modifier to a stat."""
+        self.mods[stat] = self.mods.get(stat, 0) + amount
+
+    def remove_modifier(self, stat: str, amount: int) -> None:
+        """Remove part of a modifier from a stat."""
+        self.mods[stat] = self.mods.get(stat, 0) - amount
+
+    def get(self, stat: str) -> int:
+        """Return the current value for ``stat``."""
+        return self.base.get(stat, 0) + self.mods.get(stat, 0)
+
+    def to_dict(self) -> dict[str, int]:
+        """Return all stats including modifiers."""
+        return {s: self.get(s) for s in self.base}

--- a/hololive_coliseum/status_effects.py
+++ b/hololive_coliseum/status_effects.py
@@ -1,0 +1,73 @@
+import pygame
+
+class StatusEffect:
+    """Base status effect applied to a sprite."""
+
+    def __init__(self, duration_ms: int) -> None:
+        self.start_time = pygame.time.get_ticks()
+        self.end_time = self.start_time + duration_ms
+
+    def apply(self, target):
+        pass
+
+    def update(self, target):
+        pass
+
+    def remove(self, target):
+        pass
+
+
+class FreezeEffect(StatusEffect):
+    """Halve target speed for a short duration."""
+
+    def __init__(self, duration_ms: int = 1000, factor: float = 0.5) -> None:
+        super().__init__(duration_ms)
+        self.factor = factor
+
+    def apply(self, target):
+        if hasattr(target, "speed_factor"):
+            target.speed_factor *= self.factor
+        target.velocity.x *= self.factor
+        target.velocity.y *= self.factor
+
+    def remove(self, target):
+        if hasattr(target, "speed_factor"):
+            target.speed_factor /= self.factor
+
+
+class SlowEffect(StatusEffect):
+    """Reduce horizontal speed of the target."""
+
+    def __init__(self, duration_ms: int = 1000, factor: float = 0.5) -> None:
+        super().__init__(duration_ms)
+        self.factor = factor
+
+    def apply(self, target):
+        if hasattr(target, "speed_factor"):
+            target.speed_factor *= self.factor
+        target.velocity.x *= self.factor
+
+    def remove(self, target):
+        if hasattr(target, "speed_factor"):
+            target.speed_factor /= self.factor
+
+
+class StatusEffectManager:
+    """Keep track of active status effects on sprites."""
+
+    def __init__(self) -> None:
+        self._effects: list[tuple[object, StatusEffect]] = []
+
+    def add_effect(self, target, effect: StatusEffect) -> None:
+        effect.apply(target)
+        self._effects.append((target, effect))
+
+    def update(self, now: int | None = None) -> None:
+        if now is None:
+            now = pygame.time.get_ticks()
+        for target, effect in list(self._effects):
+            if now >= effect.end_time:
+                effect.remove(target)
+                self._effects.remove((target, effect))
+            else:
+                effect.update(target)

--- a/hololive_coliseum/support_manager.py
+++ b/hololive_coliseum/support_manager.py
@@ -1,0 +1,15 @@
+class SupportManager:
+    """Track support tickets from players."""
+
+    def __init__(self) -> None:
+        self.tickets: dict[int, str] = {}
+        self.next_id = 1
+
+    def submit(self, message: str) -> int:
+        ticket_id = self.next_id
+        self.next_id += 1
+        self.tickets[ticket_id] = message
+        return ticket_id
+
+    def get(self, ticket_id: int) -> str | None:
+        return self.tickets.get(ticket_id)

--- a/hololive_coliseum/sync_manager.py
+++ b/hololive_coliseum/sync_manager.py
@@ -1,0 +1,11 @@
+class SyncManager:
+    """Maintain a time offset for client prediction."""
+
+    def __init__(self) -> None:
+        self.offset = 0
+
+    def update(self, remote_time: int, local_time: int) -> None:
+        self.offset = remote_time - local_time
+
+    def to_local(self, remote_time: int) -> int:
+        return remote_time - self.offset

--- a/hololive_coliseum/threat_manager.py
+++ b/hololive_coliseum/threat_manager.py
@@ -1,0 +1,13 @@
+class ThreatManager:
+    """Maintain simple threat tables for AI focus."""
+
+    def __init__(self) -> None:
+        self.table: dict = {}
+
+    def add_threat(self, actor, amount: int) -> None:
+        self.table[actor] = self.table.get(actor, 0) + amount
+
+    def highest_threat(self):
+        if not self.table:
+            return None
+        return max(self.table, key=self.table.get)

--- a/hololive_coliseum/title_manager.py
+++ b/hololive_coliseum/title_manager.py
@@ -1,0 +1,17 @@
+class TitleManager:
+    """Manage unlockable titles and the active one."""
+    def __init__(self):
+        self.unlocked = set()
+        self.active = None
+
+    def unlock(self, title: str) -> None:
+        self.unlocked.add(title)
+
+    def set_active(self, title: str) -> bool:
+        if title in self.unlocked:
+            self.active = title
+            return True
+        return False
+
+    def get_active(self):
+        return self.active

--- a/hololive_coliseum/trade_manager.py
+++ b/hololive_coliseum/trade_manager.py
@@ -1,0 +1,16 @@
+class TradeManager:
+    """Handle simple item trades between players."""
+
+    def __init__(self) -> None:
+        self._pending: dict[int, tuple[str, str, str]] = {}
+        self._next_id: int = 1
+
+    def propose_trade(self, from_player: str, to_player: str, item: str) -> int:
+        tid = self._next_id
+        self._next_id += 1
+        self._pending[tid] = (from_player, to_player, item)
+        return tid
+
+    def accept_trade(self, trade_id: int):
+        """Accept and remove a pending trade, returning its info."""
+        return self._pending.pop(trade_id, None)

--- a/hololive_coliseum/ui_manager.py
+++ b/hololive_coliseum/ui_manager.py
@@ -1,0 +1,12 @@
+class UIManager:
+    """Track active UI elements for drawing."""
+
+    def __init__(self):
+        self.elements = []
+
+    def add(self, elem) -> None:
+        self.elements.append(elem)
+
+    def remove(self, elem) -> None:
+        if elem in self.elements:
+            self.elements.remove(elem)

--- a/hololive_coliseum/voice_chat_manager.py
+++ b/hololive_coliseum/voice_chat_manager.py
@@ -1,0 +1,14 @@
+class VoiceChatManager:
+    """Track users joined to voice chat channels."""
+
+    def __init__(self):
+        self.channels = {}
+
+    def join(self, user: str, channel: str) -> None:
+        self.channels.setdefault(channel, set()).add(user)
+
+    def leave(self, user: str, channel: str) -> None:
+        if channel in self.channels:
+            self.channels[channel].discard(user)
+            if not self.channels[channel]:
+                del self.channels[channel]

--- a/main.py
+++ b/main.py
@@ -1,0 +1,4 @@
+from hololive_coliseum.game import main
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pygame>=2.5
+cryptography>=42

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import pygame
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from hololive_coliseum import load_accounts, register_account, delete_account
+
+
+def test_register_and_delete_account(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.accounts.SAVE_DIR', tmp_path)
+    monkeypatch.setattr('hololive_coliseum.accounts.ACCOUNTS_FILE', tmp_path / 'a.json')
+    os.makedirs(tmp_path, exist_ok=True)
+    register_account('alice', 'user', 'PUB')
+    assert load_accounts() == {'alice': {'level': 'user', 'public_key': 'PUB'}}
+    delete_account('alice')
+    assert load_accounts() == {}
+
+
+def test_execute_account_option(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.accounts.SAVE_DIR', tmp_path)
+    monkeypatch.setattr('hololive_coliseum.accounts.ACCOUNTS_FILE', tmp_path / 'b.json')
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    game.account_id = 'bob'
+    game.execute_account_option('Register Account')
+    assert load_accounts() == {'bob': {'level': 'user', 'public_key': 'PUBKEY'}}
+    game.execute_account_option('Delete Account')
+    assert load_accounts() == {}
+    pygame.quit()

--- a/tests/test_additional_managers.py
+++ b/tests/test_additional_managers.py
@@ -1,0 +1,96 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from hololive_coliseum.auth_manager import AuthManager
+from hololive_coliseum.cheat_detection_manager import CheatDetectionManager
+from hololive_coliseum.ban_manager import BanManager
+from hololive_coliseum.data_protection_manager import DataProtectionManager
+from hololive_coliseum.logging_manager import LoggingManager
+from hololive_coliseum.ui_manager import UIManager
+from hololive_coliseum.notification_manager import NotificationManager
+from hololive_coliseum.input_manager import InputManager
+from hololive_coliseum.accessibility_manager import AccessibilityManager
+from hololive_coliseum.chat_manager import ChatManager
+from hololive_coliseum.voice_chat_manager import VoiceChatManager
+from hololive_coliseum.emote_manager import EmoteManager
+from hololive_coliseum.sound_manager import SoundManager
+from hololive_coliseum.effect_manager import EffectManager
+
+
+def test_auth_and_ban_managers():
+    auth = AuthManager()
+    auth.register('u', 'p')
+    token = auth.login('u', 'p')
+    assert token and auth.verify(token)
+    ban = BanManager()
+    ban.ban('u')
+    assert ban.is_banned('u')
+    ban.unban('u')
+    assert not ban.is_banned('u')
+
+
+def test_cheat_detection_and_logging():
+    cheat = CheatDetectionManager()
+    log = LoggingManager()
+    if cheat.check_speed(11, 10):
+        log.log('speed')
+    assert log.events == ['speed']
+
+
+def test_data_protection_roundtrip():
+    dp = DataProtectionManager(b'k')
+    enc = dp.encrypt(b'abc')
+    assert dp.decrypt(enc) == b'abc'
+
+
+def test_ui_and_notification_managers():
+    ui = UIManager()
+    ui.add('menu')
+    ui.remove('menu')
+    assert not ui.elements
+    nm = NotificationManager()
+    nm.push('hi')
+    assert nm.pop() == 'hi'
+
+
+def test_input_and_accessibility():
+    im = InputManager({'jump': 1})
+    assert im.get('jump') == 1
+    im.set('fire', 2)
+    assert im.get('fire') == 2
+    am = AccessibilityManager()
+    orig = am.options['colorblind']
+    am.toggle('colorblind')
+    assert am.options['colorblind'] != orig
+
+
+def test_chat_and_voice_managers():
+    chat = ChatManager(max_messages=2)
+    chat.show()
+    assert chat.open
+    chat.send('a', 'hi')
+    chat.send('b', 'yo')
+    chat.send('c', 'hey')
+    assert chat.history() == [('b', 'yo'), ('c', 'hey')]
+    chat.hide()
+    assert not chat.open
+    voice = VoiceChatManager()
+    voice.join('a', 'c1')
+    assert 'a' in voice.channels['c1']
+    voice.leave('a', 'c1')
+    assert 'c1' not in voice.channels
+
+
+def test_emote_sound_effect():
+    em = EmoteManager()
+    em.add('smile', ':)')
+    assert em.get('smile') == ':)'
+    sound = SoundManager()
+    sound.play('ding')
+    assert sound.last_played == 'ding'
+    sound.stop()
+    assert sound.last_played is None
+    effect = EffectManager()
+    effect.trigger('boom')
+    assert 'boom' in effect.active

--- a/tests/test_ai_npc_managers.py
+++ b/tests/test_ai_npc_managers.py
@@ -1,0 +1,35 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import pygame
+from hololive_coliseum.player import PlayerCharacter, Enemy
+from hololive_coliseum.ai_manager import AIManager
+from hololive_coliseum.npc_manager import NPCManager
+from hololive_coliseum.ally_manager import AllyManager
+
+
+def test_ai_manager_actions(monkeypatch):
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    player = PlayerCharacter(100, 100)
+    enemy = Enemy(0, 100, difficulty="Hard")
+    enemy.last_ai_action = -1000
+    mgr = AIManager(pygame.sprite.Group(enemy))
+    monkeypatch.setattr('random.random', lambda: 0.0)
+    projs, melees = mgr.update(player, pygame.time.get_ticks(), [], [])
+    assert projs or melees
+    pygame.quit()
+
+
+def test_npc_and_ally_manager_groups():
+    mgr = NPCManager()
+    ally_mgr = AllyManager(mgr.allies)
+    p1 = PlayerCharacter(0, 0)
+    p2 = PlayerCharacter(0, 0)
+    mgr.add_enemy(p1)
+    mgr.add_ally(p2)
+    assert p1 in mgr.enemies
+    assert p2 in mgr.allies
+    ally_mgr.update(p1, 100, 0)

--- a/tests/test_background_managers.py
+++ b/tests/test_background_managers.py
@@ -1,0 +1,62 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from hololive_coliseum.script_manager import ScriptManager
+from hololive_coliseum.localization_manager import LocalizationManager
+from hololive_coliseum.resource_manager import ResourceManager
+from hololive_coliseum.cluster_manager import ClusterManager
+from hololive_coliseum.matchmaking_manager import MatchmakingManager
+from hololive_coliseum.load_balancer_manager import LoadBalancerManager
+from hololive_coliseum.migration_manager import MigrationManager
+from hololive_coliseum.billing_manager import BillingManager
+from hololive_coliseum.ad_manager import AdManager
+from hololive_coliseum.api_manager import APIManager
+from hololive_coliseum.support_manager import SupportManager
+
+
+def test_script_manager_basic():
+    sm = ScriptManager()
+    sm.add_script("start", "print('hi')")
+    assert sm.get_script("start") == "print('hi')"
+    sm.remove_script("start")
+    assert sm.get_script("start") is None
+
+
+def test_localization_and_resources():
+    lm = LocalizationManager()
+    lm.set("es", "hello", "hola")
+    assert lm.translate("hello", "es") == "hola"
+    rm = ResourceManager()
+    loaded = rm.load("x", lambda p: p.upper())
+    assert loaded == "X" and rm.load("x", lambda p: "y") == "X"
+
+
+def test_cluster_matchmaking_balance_and_migration():
+    cm = ClusterManager()
+    cm.register("s1")
+    lb = LoadBalancerManager()
+    lb.update_load("s1", 5)
+    assert lb.best_server() == "s1"
+    mm = MatchmakingManager()
+    mm.join("p1")
+    mm.join("p2")
+    assert mm.match() == ["p1", "p2"]
+    mig = MigrationManager()
+    mig.request_transfer("p3", "s2")
+    assert mig.complete_transfer("p3") == "s2"
+
+
+def test_billing_ad_api_support():
+    bm = BillingManager()
+    bm.add_purchase("u", "sword")
+    assert bm.get_purchases("u") == ["sword"]
+    adm = AdManager()
+    adm.add_ad("sale")
+    assert adm.current_ads() == ["sale"]
+    api = APIManager()
+    api.add_endpoint("discord", "url")
+    assert api.get("discord") == "url"
+    sup = SupportManager()
+    tid = sup.submit("help")
+    assert sup.get(tid) == "help"

--- a/tests/test_blockchain.py
+++ b/tests/test_blockchain.py
@@ -1,0 +1,130 @@
+import os
+import sys
+import json
+import hashlib
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from hololive_coliseum import (
+    load_chain,
+    add_game,
+    search,
+    add_contract,
+    fulfill_contract,
+    load_balances,
+    verify_chain,
+    merge_chain,
+    register_account,
+    load_accounts,
+    add_message,
+    decrypt_message,
+    admin_decrypt,
+)
+
+
+def test_add_and_search(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.blockchain.SAVE_DIR', tmp_path)
+    monkeypatch.setattr('hololive_coliseum.blockchain.CHAIN_FILE', tmp_path / 'c.json')
+    monkeypatch.setattr('hololive_coliseum.blockchain.BALANCE_FILE', tmp_path / 'b.json')
+    monkeypatch.setattr('hololive_coliseum.blockchain.CONTRACT_FILE', tmp_path / 'contracts.json')
+    monkeypatch.setattr('hololive_coliseum.accounts.SAVE_DIR', tmp_path)
+    monkeypatch.setattr('hololive_coliseum.accounts.ACCOUNTS_FILE', tmp_path / 'accounts.json')
+
+    register_account('alice', 'user', 'pubA')
+    register_account('bob', 'user', 'pubB')
+    block = add_game(['alice', 'bob'], 'alice', bet=5, game_id='g1')
+    assert block['index'] == 0
+    assert search(game_id='g1')[0]['winner'] == 'alice'
+
+    balances = load_balances()
+    assert balances['alice'] == 5
+    assert balances['bob'] == -5
+    from hololive_coliseum.blockchain import get_balance
+    assert get_balance('alice') == 5
+    assert get_balance('bob') == -5
+
+
+def test_contract_flow(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.blockchain.SAVE_DIR', tmp_path)
+    monkeypatch.setattr('hololive_coliseum.blockchain.CHAIN_FILE', tmp_path / 'c.json')
+    monkeypatch.setattr('hololive_coliseum.blockchain.BALANCE_FILE', tmp_path / 'b.json')
+    monkeypatch.setattr('hololive_coliseum.blockchain.CONTRACT_FILE', tmp_path / 'contracts.json')
+    monkeypatch.setattr('hololive_coliseum.accounts.SAVE_DIR', tmp_path)
+    monkeypatch.setattr('hololive_coliseum.accounts.ACCOUNTS_FILE', tmp_path / 'accounts.json')
+
+    register_account('a', 'user', 'pubA')
+    register_account('b', 'user', 'pubB')
+    add_contract('req1', ['a', 'b'], 2)
+    block = fulfill_contract('req1', 'b')
+    assert block['game_id'] == 'req1'
+    chain = load_chain()
+    assert len(chain) == 1
+    assert chain[0]['winner'] == 'b'
+
+
+def test_verify_and_merge(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.blockchain.SAVE_DIR', tmp_path)
+    monkeypatch.setattr('hololive_coliseum.blockchain.CHAIN_FILE', tmp_path / 'c.json')
+    monkeypatch.setattr('hololive_coliseum.blockchain.BALANCE_FILE', tmp_path / 'b.json')
+    monkeypatch.setattr('hololive_coliseum.blockchain.CONTRACT_FILE', tmp_path / 'contracts.json')
+    monkeypatch.setattr('hololive_coliseum.accounts.SAVE_DIR', tmp_path)
+    monkeypatch.setattr('hololive_coliseum.accounts.ACCOUNTS_FILE', tmp_path / 'accounts.json')
+
+    register_account('a', 'user', 'pubA')
+    register_account('b', 'user', 'pubB')
+    local = [add_game(['a'], 'a', game_id='g1')]
+    assert verify_chain(local)
+    remote = local + [
+        {
+            'index': 1,
+            'game_id': 'g2',
+            'players': ['a', 'b'],
+            'winner': 'b',
+            'bet': 0,
+            'timestamp': local[0]['timestamp'] + 1,
+            'prev_hash': local[0]['hash'],
+        }
+    ]
+    remote[1]['hash'] = hashlib.sha256(json.dumps(remote[1], sort_keys=True).encode('utf-8')).hexdigest()
+    merge_chain(remote)
+    assert len(load_chain()) == 2
+
+
+def test_message_encryption(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.blockchain.SAVE_DIR', tmp_path)
+    monkeypatch.setattr('hololive_coliseum.blockchain.CHAIN_FILE', tmp_path / 'c.json')
+    monkeypatch.setattr('hololive_coliseum.blockchain.BALANCE_FILE', tmp_path / 'b.json')
+    monkeypatch.setattr('hololive_coliseum.blockchain.CONTRACT_FILE', tmp_path / 'contracts.json')
+    monkeypatch.setattr('hololive_coliseum.accounts.SAVE_DIR', tmp_path)
+    monkeypatch.setattr('hololive_coliseum.accounts.ACCOUNTS_FILE', tmp_path / 'accounts.json')
+
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.primitives import serialization
+
+    admin_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    admin_pub = admin_key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    user_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    user_pub = user_key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    register_account('bob', 'user', user_pub.decode('ascii'))
+    block = add_message('alice', 'bob', 'hello', admin_pub)
+
+    msg_user = decrypt_message(block, user_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ))
+    msg_admin = admin_decrypt(block, admin_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ))
+    assert msg_user == 'hello'
+    assert msg_admin == 'hello'

--- a/tests/test_economy_managers.py
+++ b/tests/test_economy_managers.py
@@ -1,0 +1,39 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from hololive_coliseum.crafting_manager import CraftingManager
+from hololive_coliseum.profession_manager import ProfessionManager
+from hololive_coliseum.trade_manager import TradeManager
+from hololive_coliseum.economy_manager import EconomyManager
+from hololive_coliseum.inventory_manager import InventoryManager
+
+
+def test_crafting_manager_craft():
+    inv = InventoryManager()
+    inv.add("wood", 2)
+    cm = CraftingManager()
+    cm.add_recipe("stick", {"wood": 2}, "stick")
+    crafted = cm.craft("stick", inv)
+    assert crafted == "stick" and inv.count("stick") == 1
+
+
+def test_profession_levels():
+    pm = ProfessionManager()
+    pm.gain_xp("mining", 250)
+    assert pm.level_of("mining") == 2
+
+
+def test_trade_manager_accept():
+    tm = TradeManager()
+    tid = tm.propose_trade("a", "b", "gem")
+    assert tm.accept_trade(tid) == ("a", "b", "gem")
+    assert tm.accept_trade(tid) is None
+
+
+def test_economy_manager_prices():
+    em = EconomyManager()
+    em.set_price("sword", 100)
+    assert em.get_price("sword") == 100
+    em.remove_price("sword")
+    assert em.get_price("sword") == 0

--- a/tests/test_enemy_ai.py
+++ b/tests/test_enemy_ai.py
@@ -1,0 +1,62 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import pygame
+from hololive_coliseum.player import PlayerCharacter, Enemy
+from hololive_coliseum.projectile import Projectile
+from hololive_coliseum.game import Game
+
+
+def test_enemy_difficulty_reaction(monkeypatch):
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    player = PlayerCharacter(100, 100)
+    monkeypatch.setattr('random.random', lambda: 0.0)
+    easy = Enemy(0, 100, difficulty="Easy")
+    hard = Enemy(0, 100, difficulty="Hard")
+    now = pygame.time.get_ticks()
+    assert easy.handle_ai(player, now + 150, [], []) == (None, None)
+    proj, melee = hard.handle_ai(player, now + 150, [], [])
+    assert proj or melee
+    proj2, melee2 = easy.handle_ai(player, now + 650, [], [])
+    assert proj2 or melee2
+    pygame.quit()
+
+
+def test_enemy_projectile_hits_player(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.save_manager.SAVE_DIR', tmp_path)
+    monkeypatch.setattr('random.random', lambda: 0.0)
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    game = Game()
+    game.selected_character = "Gawr Gura"
+    game.ai_players = 1
+    game.difficulty_index = 2  # Hard
+    game._setup_level()
+    enemy = next(iter(game.enemies))
+    enemy.last_ai_action = -1000
+    now = pygame.time.get_ticks()
+    proj, _ = enemy.handle_ai(game.player, now + 200, [], [])
+    assert proj is not None
+    proj.rect.center = game.player.rect.center
+    game.projectiles.add(proj)
+    game.all_sprites.add(proj)
+    game._handle_collisions()
+    assert game.player.health < game.player.max_health
+    pygame.quit()
+
+
+def test_enemy_dodges_projectile(monkeypatch):
+    monkeypatch.setattr('random.random', lambda: 0.0)
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    player = PlayerCharacter(100, 100)
+    enemy = Enemy(50, 100, difficulty="Hard")
+    proj = Projectile(55, 100, pygame.math.Vector2(-1, 0))
+    projectiles = [proj]
+    now = pygame.time.get_ticks() + 1000
+    enemy.handle_ai(player, now, [], projectiles)
+    assert enemy.dodging
+    pygame.quit()

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,0 +1,520 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+
+def test_game_initialization(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    assert game.width == 800
+    assert game.height == 600
+
+
+def test_draw_menu_fills_cyan(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game, MENU_BG_COLOR
+
+    game = Game(width=100, height=100)
+    game._draw_menu()
+    assert game.screen.get_at((0, 0))[:3] == MENU_BG_COLOR
+
+
+def test_game_has_mp_type_menu(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    assert game.mp_type_options == ["Offline", "Online", "Back"]
+
+
+def test_draw_key_bindings_menu(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game, MENU_BG_COLOR
+
+    game = Game(width=120, height=90)
+    game._draw_key_bindings_menu()
+    assert game.screen.get_at((0, 0))[:3] == MENU_BG_COLOR
+
+
+def test_controller_menu_options(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    assert "Controller Bindings" in game.settings_options
+
+
+def test_character_menu_has_ai_option(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    assert "Add AI Player" in game.character_menu_options
+
+
+def test_character_menu_has_difficulty(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    assert "Difficulty" in game.character_menu_options
+    assert game.difficulty_levels == ["Easy", "Normal", "Hard"]
+
+
+def test_watson_in_character_list(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    assert "Watson Amelia" in game.characters
+
+
+def test_ina_in_character_list(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    assert "Ninomae Ina'nis" in game.characters
+
+
+def test_fubuki_in_character_list(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    assert "Shirakami Fubuki" in game.characters
+
+
+def test_character_list_has_20_entries(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    assert len(game.characters) == 21
+    assert "Tokino Sora" in game.characters
+
+
+def test_ai_players_spawn(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    game.selected_character = "Gawr Gura"
+    game.ai_players = 2
+    game._setup_level()
+    assert len(game.enemies) == 2
+
+
+def test_setup_level_resets_timers(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    game.next_powerup_time = 123
+    game.last_enemy_damage = 456
+    game.ai_players = 0
+    game._setup_level()
+    assert game.next_powerup_time == 0
+    assert game.last_enemy_damage == 0
+
+
+def test_setup_level_adds_two_gravity_zones(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    game.ai_players = 0
+    game._setup_level()
+    assert len(game.gravity_zones) == 2
+    multipliers = sorted(zone.multiplier for zone in game.gravity_zones)
+    assert multipliers == [0.2, 2.0]
+
+
+def test_enemy_ai_moves_toward_player(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+    import pygame
+
+    game = Game()
+    game.ai_players = 1
+    game._setup_level()
+    game.last_enemy_damage = -1000
+    enemy = next(iter(game.enemies))
+    start_x = enemy.rect.x
+    now = pygame.time.get_ticks()
+    enemy.handle_ai(game.player, now, [], [])
+    enemy.update(game.ground_y, now)
+    assert enemy.rect.x != start_x
+
+
+def test_enemy_collision_hurts_player(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    import pygame
+
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    game.ai_players = 1
+    game._setup_level()
+    game.last_enemy_damage = -1000
+    enemy = next(iter(game.enemies))
+    enemy.rect.center = game.player.rect.center
+    enemy.pos = pygame.math.Vector2(enemy.rect.topleft)
+    game._handle_collisions()
+    assert game.player.health < game.player.max_health
+    pygame.quit()
+
+
+def test_chapter_list_has_20_entries(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    assert len(game.chapters) == 20
+    assert len(game.chapter_images) == 20
+
+
+def test_map_menu_has_back_option(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    assert game.map_menu_options[-1] == "Back"
+
+
+def test_character_menu_has_back_option(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    assert game.character_menu_options[-1] == "Back"
+
+
+def test_pause_menu_options(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    assert game.pause_options == ["Resume", "Main Menu"]
+
+
+def test_draw_pause_menu(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game, MENU_BG_COLOR
+
+    game = Game(width=90, height=90)
+    game._draw_pause_menu()
+    assert game.screen.get_at((0, 0))[:3] == MENU_BG_COLOR
+
+
+def test_main_menu_has_info_options(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    assert "How to Play" in game.main_menu_options
+    assert "Credits" in game.main_menu_options
+    assert "Records" in game.main_menu_options
+
+
+def test_draw_how_to_play(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game, MENU_BG_COLOR
+
+    game = Game(width=80, height=80)
+    game._draw_how_to_play()
+    assert game.screen.get_at((0, 0))[:3] == MENU_BG_COLOR
+
+
+def test_draw_credits(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game, MENU_BG_COLOR
+
+    game = Game(width=80, height=80)
+    game._draw_credits()
+    assert game.screen.get_at((0, 0))[:3] == MENU_BG_COLOR
+
+
+def test_draw_scoreboard(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game, MENU_BG_COLOR
+
+    game = Game(width=80, height=80)
+    game._draw_scoreboard_menu()
+    assert game.screen.get_at((0, 0))[:3] == MENU_BG_COLOR
+
+
+def test_escape_enters_pause(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    import pygame
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    game.state = "playing"
+    pygame.event.post(pygame.event.Event(pygame.KEYDOWN, {"key": pygame.K_ESCAPE}))
+    pygame.event.post(pygame.event.Event(pygame.QUIT))
+    game.run()
+    assert game.state == "paused"
+
+
+def test_draw_lobby_menu(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game, MENU_BG_COLOR
+
+    game = Game(width=100, height=100)
+    game.player_names = ["P1", "P2"]
+    game._draw_lobby_menu()
+    assert game.screen.get_at((0, 0))[:3] == MENU_BG_COLOR
+
+
+def test_cycle_volume(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    game.volume = 0.0
+    game._cycle_volume()
+    assert game.volume == 0.5
+    game._cycle_volume()
+    assert game.volume == 1.0
+    game._cycle_volume()
+    assert game.volume == 0.0
+
+
+def test_node_settings_menu(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    assert "Node Settings" in game.settings_options
+    assert game.node_options == ["Start Node", "Stop Node", "Latency Helper", "Back"]
+
+
+def test_accounts_menu(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    assert "Accounts" in game.settings_options
+    assert game.account_options == ["Register Account", "Delete Account", "Back"]
+
+
+def test_settings_menu_has_new_options(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    assert "Show FPS" in game.settings_options
+    assert "Reset Records" in game.settings_options
+
+
+def test_start_and_stop_node(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    game.start_node()
+    assert game.network_manager is not None
+    assert game.node_hosting
+    game.stop_node()
+    assert game.network_manager is None
+    assert not game.node_hosting
+
+
+def test_game_over_state(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    import pygame
+
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    game.selected_character = "Gawr Gura"
+    game._setup_level()
+    game.state = "playing"
+    game.player.lives = 0
+    pygame.event.post(pygame.event.Event(pygame.QUIT))
+    game.run()
+    assert game.state == "game_over"
+    pygame.quit()
+
+
+def test_best_time_saved(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    import pygame
+
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.game import Game, load_settings
+
+    game = Game()
+    game.selected_character = "Gawr Gura"
+    game._setup_level()
+    game.state = "playing"
+    game.level_start_time = pygame.time.get_ticks() - 3000
+    game.player.lives = 0
+    pygame.event.post(pygame.event.Event(pygame.QUIT))
+    game.run()
+    settings = load_settings()
+    assert settings.get("best_time", 0) >= 3
+    pygame.quit()
+
+
+def test_best_score_saved(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    import pygame
+
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.game import Game, load_settings
+
+    game = Game()
+    game.selected_character = "Gawr Gura"
+    game._setup_level()
+    game.state = "playing"
+    game.score = 5
+    game.player.lives = 0
+    pygame.event.post(pygame.event.Event(pygame.QUIT))
+    game.run()
+    settings = load_settings()
+    assert settings.get("best_score", 0) >= 5
+    pygame.quit()
+
+
+def test_enemy_kill_increments_score(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    import pygame
+
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.game import Game
+    from hololive_coliseum.projectile import Projectile
+
+    game = Game()
+    game.selected_character = "Gawr Gura"
+    game.ai_players = 1
+    game._setup_level()
+    enemy = next(iter(game.enemies))
+    enemy.health = 5
+    proj = Projectile(enemy.rect.centerx, enemy.rect.centery, pygame.math.Vector2(1, 0))
+    game.projectiles.add(proj)
+    game._handle_collisions()
+    assert game.score == 1
+    assert len(game.enemies) == 0
+    pygame.quit()
+
+
+def test_victory_state(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    import pygame
+
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    game.selected_character = "Gawr Gura"
+    game._setup_level()
+    game.state = "playing"
+    game.level_start_time = pygame.time.get_ticks() - game.level_limit * 1000 - 100
+    pygame.event.post(pygame.event.Event(pygame.QUIT))
+    game.run()
+    assert game.state == "victory"
+    pygame.quit()
+
+
+def test_final_time_victory(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    import pygame
+
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    game.selected_character = "Gawr Gura"
+    game._setup_level()
+    game.state = "playing"
+    game.level_start_time = pygame.time.get_ticks() - game.level_limit * 1000 - 100
+    pygame.event.post(pygame.event.Event(pygame.QUIT))
+    game.run()
+    assert game.final_time >= game.level_limit
+    pygame.quit()
+
+
+def test_final_time_game_over(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    import pygame
+
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    game.selected_character = "Gawr Gura"
+    game._setup_level()
+    game.state = "playing"
+    game.level_start_time = pygame.time.get_ticks() - 2000
+    game.player.lives = 0
+    pygame.event.post(pygame.event.Event(pygame.QUIT))
+    game.run()
+    assert game.final_time >= 2
+    pygame.quit()
+
+
+def test_end_menu_options(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    assert game.game_over_options == ["Play Again", "Main Menu"]
+    assert game.victory_options == ["Play Again", "Main Menu"]
+
+
+def test_play_again_returns_to_char(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    import pygame
+
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    game.state = "victory"
+    game.show_end_options = True
+    game.menu_index = 0  # Play Again
+    pygame.event.post(pygame.event.Event(pygame.KEYDOWN, {"key": pygame.K_RETURN}))
+    pygame.event.post(pygame.event.Event(pygame.QUIT))
+    game.run()
+    assert game.state == "char"
+    pygame.quit()
+
+
+def test_chat_toggle_and_send(tmp_path, monkeypatch):
+    monkeypatch.setattr("hololive_coliseum.save_manager.SAVE_DIR", tmp_path)
+    import pygame
+
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    game.selected_character = "Gawr Gura"
+    game._setup_level()
+    game.state = "playing"
+    pygame.event.post(pygame.event.Event(pygame.KEYDOWN, {"key": pygame.K_RETURN, "unicode": "\r"}))
+    pygame.event.post(pygame.event.Event(pygame.KEYDOWN, {"key": pygame.K_h, "unicode": "h"}))
+    pygame.event.post(pygame.event.Event(pygame.KEYDOWN, {"key": pygame.K_i, "unicode": "i"}))
+    pygame.event.post(pygame.event.Event(pygame.KEYDOWN, {"key": pygame.K_RETURN, "unicode": "\r"}))
+    pygame.event.post(pygame.event.Event(pygame.QUIT))
+    game.run()
+    assert not game.chat_manager.open
+    assert game.chat_manager.history() == [("Player 1", "hi")]
+    pygame.quit()

--- a/tests/test_gravity_zone.py
+++ b/tests/test_gravity_zone.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import pygame
+from hololive_coliseum.player import PlayerCharacter
+from hololive_coliseum.gravity_zone import GravityZone
+
+
+def test_player_gravity_zone():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    player = PlayerCharacter(0, 0)
+    zone = GravityZone(pygame.Rect(0, 0, 100, 100), 0.1)
+    # player inside zone
+    assert zone.rect.colliderect(player.rect)
+    player.set_gravity_multiplier(1.0)
+    if zone.rect.colliderect(player.rect):
+        player.set_gravity_multiplier(zone.multiplier)
+    player.apply_gravity()
+    assert player.velocity.y == 0.05  # GRAVITY * 0.1
+    pygame.quit()
+
+
+def test_high_gravity_zone():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    player = PlayerCharacter(0, 0)
+    zone = GravityZone(pygame.Rect(0, 0, 100, 100), 2.0)
+    assert zone.rect.colliderect(player.rect)
+    player.set_gravity_multiplier(1.0)
+    if zone.rect.colliderect(player.rect):
+        player.set_gravity_multiplier(zone.multiplier)
+    player.apply_gravity()
+    assert player.velocity.y == 1.0  # GRAVITY * 2
+    pygame.quit()

--- a/tests/test_hazards.py
+++ b/tests/test_hazards.py
@@ -1,0 +1,67 @@
+import os
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+import pygame
+
+from hololive_coliseum.hazards import SpikeTrap, IceZone, LavaZone
+from hololive_coliseum.game import Game
+from hololive_coliseum.player import Enemy
+
+
+def test_spike_trap_damages_player(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.save_manager.SAVE_DIR', tmp_path)
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    game = Game()
+    trap = SpikeTrap(game.player.rect.copy())
+    game.hazards.add(trap)
+    game.all_sprites.add(trap)
+    now = pygame.time.get_ticks()
+    game.last_hazard_damage = -1000
+    game.state = 'playing'
+    game._handle_collisions()  # to avoid unused
+    zone = pygame.sprite.spritecollideany(game.player, game.hazards)
+    if zone:
+        game.player.take_damage(trap.damage)
+    assert game.player.health < game.player.max_health
+    pygame.quit()
+
+
+def test_enemy_jumps_over_hazard(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.save_manager.SAVE_DIR', tmp_path)
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    game = Game()
+    game.ai_players = 1
+    game._setup_level()
+    enemy = next(iter(game.enemies))
+    trap_rect = enemy.rect.move(5, 0)
+    trap = SpikeTrap(trap_rect)
+    game.hazards.add(trap)
+    enemy.on_ground = True
+    now = pygame.time.get_ticks() + 1000
+    enemy.handle_ai(game.player, now, game.hazards, [])
+    assert enemy.velocity.y == -10
+    pygame.quit()
+
+
+def test_lava_zone_damage(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.save_manager.SAVE_DIR', tmp_path)
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    game = Game()
+    lava = LavaZone(game.player.rect.copy(), damage=3, interval=0)
+    game.hazards.add(lava)
+    game.all_sprites.add(lava)
+    now = pygame.time.get_ticks()
+    game.last_hazard_damage = -1000
+    game.state = 'playing'
+    hazard = pygame.sprite.spritecollideany(game.player, game.hazards)
+    if hazard:
+        game.player.take_damage(lava.damage)
+        game.last_hazard_damage = now
+    assert game.player.health < game.player.max_health
+    pygame.quit()
+

--- a/tests/test_holographic_compression.py
+++ b/tests/test_holographic_compression.py
@@ -1,0 +1,39 @@
+import json
+from hololive_coliseum.holographic_compression import (
+    compress_packet,
+    decompress_packet,
+)
+
+
+def test_compress_roundtrip():
+    msg = {"type": "demo", "value": 42}
+    packet = compress_packet(msg)
+    out = decompress_packet(packet)
+    assert out == msg
+
+
+def test_compress_encrypt_roundtrip():
+    msg = {"type": "demo", "value": 43}
+    key = b"key"
+    packet = compress_packet(msg, key)
+    out = decompress_packet(packet, key)
+    assert out == msg
+
+
+def test_anchor_points_present():
+    msg = {"hello": "world"}
+    packet = compress_packet(msg)
+    wrapper = json.loads(packet.decode("utf-8"))
+    anchors = wrapper.get("p")
+    assert isinstance(anchors, list) and len(anchors) == 4
+    expected = [
+        ([0, 0, 0], "black"),
+        ([1, 0, 0], "red"),
+        ([1, 1, 1], "white"),
+        ([1, 0, 1], "cyan"),
+    ]
+    for anchor, (pos, color) in zip(anchors, expected):
+        assert anchor["pos"] == pos
+        assert anchor["color"] == color
+        assert "vparam" in anchor
+

--- a/tests/test_menu_state_managers.py
+++ b/tests/test_menu_state_managers.py
@@ -1,0 +1,24 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from hololive_coliseum.menu_manager import MenuManager
+from hololive_coliseum.game_state_manager import GameStateManager
+
+
+def test_menu_manager_wraps():
+    mgr = MenuManager()
+    mgr.move(1, 3)
+    assert mgr.index == 1
+    mgr.move(-1, 3)
+    assert mgr.index == 0
+    mgr.move(-1, 3)
+    assert mgr.index == 2
+
+
+def test_game_state_manager_change_and_revert():
+    mgr = GameStateManager("a")
+    mgr.change("b")
+    assert mgr.state == "b" and mgr.previous == "a"
+    mgr.revert()
+    assert mgr.state == "a"

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,0 +1,247 @@
+import time
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from hololive_coliseum.network import NetworkManager
+from hololive_coliseum.state_sync import StateSync
+from hololive_coliseum.node_registry import load_nodes, add_node
+from hololive_coliseum.save_manager import load_settings
+
+
+def test_network_send_receive():
+    host = NetworkManager(host=True, address=("127.0.0.1", 0), encrypt_key=b"k")
+    addr = host.sock.getsockname()
+    client = NetworkManager(host=False, address=addr, encrypt_key=b"k")
+    sync = StateSync()
+    msg = {"x": 1}
+    client.send_state(msg)
+    # Give OS time to deliver
+    time.sleep(0.01)
+    received = host.poll()
+    assert received
+    state = sync.apply(received[0][1])
+    assert state == msg
+    host.sock.close()
+    client.sock.close()
+
+
+def test_network_discovery():
+    host = NetworkManager(host=True, address=("", 0))
+    port = host.sock.getsockname()[1]
+    time.sleep(0.01)
+    servers = NetworkManager.discover(
+        timeout=0.1,
+        port=port,
+        broadcast_address="127.0.0.1",
+        process_host=host.poll,
+    )
+    assert any(addr[1] == port for addr in servers)
+    host.sock.close()
+
+
+def test_network_announce(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.node_registry.SAVE_DIR', tmp_path)
+    monkeypatch.setattr('hololive_coliseum.node_registry.NODES_FILE', tmp_path / 'nodes.json')
+    monkeypatch.setattr('hololive_coliseum.node_registry.DEFAULT_NODES', [])
+    host = NetworkManager(host=True, address=("127.0.0.1", 0))
+    host_addr = host.sock.getsockname()
+    client = NetworkManager(host=False, address=host_addr)
+    client.broadcast_announce([host_addr])
+    time.sleep(0.01)
+    host.poll()
+    nodes = load_nodes()
+    assert nodes[0] == host_addr
+    assert len(nodes) == 2
+    host.sock.close()
+    client.sock.close()
+
+
+def test_ping_node():
+    host = NetworkManager(host=True, address=("127.0.0.1", 0))
+    addr = host.sock.getsockname()
+
+    def process():
+        host.poll()
+
+    latency = NetworkManager.ping_node(addr, timeout=0.5, process_host=process)
+    assert latency is not None and latency < 0.5
+    host.sock.close()
+
+
+def test_select_best_node(monkeypatch):
+    nodes = [("1.1.1.1", 1), ("2.2.2.2", 2)]
+    latencies = {nodes[0]: 0.3, nodes[1]: 0.1}
+
+    def fake_ping(node):
+        return latencies[node]
+
+    best = NetworkManager.select_best_node(nodes, ping_func=fake_ping)
+    assert best == nodes[1]
+
+
+def test_register_and_find_games():
+    router = NetworkManager(host=True, address=("127.0.0.1", 0))
+    router_addr = router.sock.getsockname()
+    host = NetworkManager(host=False, address=router_addr)
+    host.register_game([router_addr])
+    time.sleep(0.01)
+    router.poll()
+
+    games = NetworkManager.request_games(router_addr, timeout=0.1, process_host=router.poll)
+    ports = [port for _, port in games]
+    assert host.sock.getsockname()[1] in ports
+
+    host.sock.close()
+    router.sock.close()
+
+
+def test_register_and_find_clients():
+    router = NetworkManager(host=True, address=("127.0.0.1", 0))
+    router_addr = router.sock.getsockname()
+    client = NetworkManager(host=False, address=router_addr)
+    client.register_client([router_addr])
+    time.sleep(0.01)
+    router.poll()
+
+    clients = NetworkManager.request_clients(router_addr, timeout=0.1, process_host=router.poll)
+    ports = [port for _, port in clients]
+    assert client.sock.getsockname()[1] in ports
+
+    client.sock.close()
+    router.sock.close()
+
+
+def test_nodes_share_games(monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.node_registry.SAVE_DIR', Path('test_nodes'))
+    monkeypatch.setattr('hololive_coliseum.node_registry.NODES_FILE', Path('test_nodes/nodes.json'))
+    monkeypatch.setattr('hololive_coliseum.node_registry.DEFAULT_NODES', [])
+    os.makedirs('test_nodes', exist_ok=True)
+
+    router1 = NetworkManager(host=True, address=("127.0.0.1", 0))
+    router2 = NetworkManager(host=True, address=("127.0.0.1", 0))
+    addr1 = router1.sock.getsockname()
+    addr2 = router2.sock.getsockname()
+    add_node(addr1)
+    add_node(addr2)
+
+    # announce each other so they learn peers
+    router1.broadcast_announce([addr2])
+    router2.broadcast_announce([addr1])
+    time.sleep(0.01)
+    router1.poll(); router2.poll()
+
+    host = NetworkManager(host=False, address=addr1)
+    host.register_game([addr1])
+    time.sleep(0.01)
+    router1.poll(); router2.poll()
+
+    assert addr2 in load_nodes()
+    host_port = host.sock.getsockname()[1]
+    assert any(port == host_port for _, port in router2.games)
+
+    host.sock.close()
+    router1.sock.close()
+    router2.sock.close()
+
+
+def test_nodes_share_clients(monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.node_registry.SAVE_DIR', Path('test_nodes2'))
+    monkeypatch.setattr('hololive_coliseum.node_registry.NODES_FILE', Path('test_nodes2/nodes.json'))
+    monkeypatch.setattr('hololive_coliseum.node_registry.DEFAULT_NODES', [])
+    os.makedirs('test_nodes2', exist_ok=True)
+
+    router1 = NetworkManager(host=True, address=("127.0.0.1", 0))
+    router2 = NetworkManager(host=True, address=("127.0.0.1", 0))
+    addr1 = router1.sock.getsockname()
+    addr2 = router2.sock.getsockname()
+    add_node(addr1)
+    add_node(addr2)
+
+    router1.broadcast_announce([addr2])
+    router2.broadcast_announce([addr1])
+    time.sleep(0.01)
+    router1.poll(); router2.poll()
+
+    client = NetworkManager(host=False, address=addr1)
+    client.register_client([addr1])
+    time.sleep(0.01)
+    router1.poll(); router2.poll()
+
+    assert addr2 in load_nodes()
+    assert any(port == client.sock.getsockname()[1] for _, port in router2.live_clients)
+
+    client.sock.close()
+    router1.sock.close()
+    router2.sock.close()
+
+def test_state_sync_delta():
+    sync = StateSync()
+    first = sync.encode({'x': 1, 'y': 2})
+    assert first['seq'] == 1 and first['x'] == 1 and first['y'] == 2
+    second = sync.encode({'x': 1, 'y': 3})
+    assert second == {'y': 3, 'seq': 2}
+    state = sync.apply(second)
+    assert state == {'x': 1, 'y': 3}
+
+
+def test_reliable_packets():
+    host = NetworkManager(host=True, address=("127.0.0.1", 0))
+    addr = host.sock.getsockname()
+    client = NetworkManager(host=False, address=addr)
+
+    client.send_reliable({"type": "hello"}, max_retries=1, importance=2)
+    # wait less than ack_timeout to trigger resend check
+    time.sleep(client.ack_timeout / 2 + 0.01)
+    client.process_reliable()
+    key = list(client._pending_acks.keys())[0]
+    # after one resend a retry was consumed
+    assert client._pending_acks[key][2] == 1
+    # host processes message and sends ack
+    host.poll()
+    time.sleep(0.01)
+    client.poll()
+    assert not client._pending_acks
+    host.sock.close()
+    client.sock.close()
+
+def test_records_update(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.save_manager.SAVE_DIR', tmp_path)
+    monkeypatch.setattr('hololive_coliseum.node_registry.SAVE_DIR', tmp_path)
+    monkeypatch.setattr('hololive_coliseum.node_registry.NODES_FILE', tmp_path / 'nodes.json')
+    monkeypatch.setattr('hololive_coliseum.node_registry.DEFAULT_NODES', [])
+    host = NetworkManager(host=True, address=("127.0.0.1", 0))
+    client = NetworkManager(host=False, address=host.sock.getsockname())
+    # send records from host to client
+    host.broadcast_records(5.0, 12, [client.sock.getsockname()])
+    time.sleep(0.01)
+    client.poll()
+    data = load_settings()
+    assert data['best_time'] == 5.0 and data['best_score'] == 12
+    host.sock.close()
+    client.sock.close()
+
+
+def test_relay_forwarding():
+    relay = NetworkManager(host=True, address=("127.0.0.1", 0), relay_mode=True)
+    relay_addr = relay.sock.getsockname()
+    host = NetworkManager(host=True, address=("127.0.0.1", 0))
+    host_addr = host.sock.getsockname()
+    client = NetworkManager(host=False, address=relay_addr, relay_addr=relay_addr)
+
+    client.send_via_relay({"type": "hello"}, host_addr)
+    time.sleep(0.01)
+    relay.poll()
+    msgs = host.poll()
+    assert msgs and msgs[0][1]["type"] == "hello"
+
+    client.sock.close()
+    host.sock.close()
+    relay.sock.close()
+
+
+def test_select_best_node_empty():
+    assert NetworkManager.select_best_node([]) is None
+

--- a/tests/test_new_managers.py
+++ b/tests/test_new_managers.py
@@ -1,0 +1,70 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from hololive_coliseum.combat_manager import CombatManager
+from hololive_coliseum.damage_manager import DamageManager
+from hololive_coliseum.threat_manager import ThreatManager
+from hololive_coliseum.loot_manager import LootManager
+from hololive_coliseum.buff_manager import BuffManager
+from hololive_coliseum.status_effects import FreezeEffect
+
+class Dummy:
+    def __init__(self):
+        self.hp = 100
+        class V:
+            x = 0
+            y = 0
+        self.velocity = V()
+    def take_damage(self, amt):
+        self.hp -= amt
+
+
+def test_combat_manager_order():
+    cm = CombatManager()
+    cm.add("a")
+    cm.add("b")
+    cm.add("c")
+    assert cm.next_actor() == "a"
+    assert cm.next_actor() == "b"
+    assert cm.next_actor() == "c"
+    assert cm.next_actor() == "a"
+
+
+def test_damage_manager_apply():
+    dm = DamageManager()
+    dummy = Dummy()
+    dm.apply(dummy, 20, defense=5)
+    assert dummy.hp == 85
+
+
+def test_threat_manager_highest():
+    tm = ThreatManager()
+    tm.add_threat("p1", 5)
+    tm.add_threat("p2", 10)
+    assert tm.highest_threat() == "p2"
+
+
+def test_loot_manager_roll(monkeypatch):
+    lm = LootManager({"orc": ["gold", "axe"]})
+    monkeypatch.setattr("random.choice", lambda seq: seq[1])
+    assert lm.roll_loot("orc") == "axe"
+
+
+def test_buff_manager_update():
+    bm = BuffManager()
+    dummy = Dummy()
+    dummy.speed_factor = 1.0
+    bm.add_buff(dummy, FreezeEffect(duration_ms=10))
+    assert dummy.speed_factor < 1.0
+    bm.update(pygame_time(dummy))
+    assert dummy.speed_factor == 1.0
+
+
+def pygame_time(dummy):
+    import pygame
+    pygame.init()
+    pygame.display.set_mode((1,1))
+    now = pygame.time.get_ticks() + 20
+    pygame.quit()
+    return now

--- a/tests/test_node_registry.py
+++ b/tests/test_node_registry.py
@@ -1,0 +1,37 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from hololive_coliseum.node_registry import load_nodes, save_nodes, add_node, prune_nodes
+
+
+def test_add_node_dedup(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.node_registry.SAVE_DIR', tmp_path)
+    monkeypatch.setattr('hololive_coliseum.node_registry.NODES_FILE', tmp_path / 'nodes.json')
+    monkeypatch.setattr('hololive_coliseum.node_registry.DEFAULT_NODES', [])
+    add_node(('1.2.3.4', 1234))
+    assert load_nodes() == [('1.2.3.4', 1234)]
+    add_node(('1.2.3.4', 1234))
+    assert load_nodes() == [('1.2.3.4', 1234)]
+
+
+def test_prune_nodes(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.node_registry.SAVE_DIR', tmp_path)
+    monkeypatch.setattr('hololive_coliseum.node_registry.NODES_FILE', tmp_path / 'nodes.json')
+    monkeypatch.setattr('hololive_coliseum.node_registry.DEFAULT_NODES', [])
+    save_nodes([('1.1.1.1', 1), ('2.2.2.2', 2)])
+
+    def fake_ping(addr):
+        return 0.1 if addr[0] == '1.1.1.1' else None
+
+    prune_nodes(fake_ping)
+    assert load_nodes() == [('1.1.1.1', 1)]
+
+
+def test_load_nodes_falls_back_to_defaults(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.node_registry.SAVE_DIR', tmp_path)
+    monkeypatch.setattr('hololive_coliseum.node_registry.NODES_FILE', tmp_path / 'nodes.json')
+    monkeypatch.setattr('hololive_coliseum.node_registry.DEFAULT_NODES', [('4.4.4.4', 4444)])
+    # No nodes.json file yet
+    assert load_nodes() == [('4.4.4.4', 4444)]

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1,0 +1,458 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+import pygame
+
+from hololive_coliseum.player import PlayerCharacter
+
+
+def test_player_gravity():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    player = PlayerCharacter(0, 0)
+    player.update(ground_y=1000)
+    assert player.velocity.y > 0
+    pygame.quit()
+
+
+def test_player_friction_slows_movement():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    player = PlayerCharacter(0, 0)
+    player.velocity.x = 3
+    player.on_ground = True
+    dummy_keys = type('D', (), {'__getitem__': lambda self, key: False})()
+    player.handle_input(dummy_keys, pygame.time.get_ticks(), action_pressed=lambda a: False)
+    player.update(ground_y=1000)
+    assert player.velocity.x < 3
+    pygame.quit()
+
+
+def test_player_loads_image():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    image_path = os.path.join(
+        os.path.dirname(__file__), "..", "Images", "Gawr_Gura_right.png"
+    )
+    player = PlayerCharacter(0, 0, image_path)
+    assert player.image.get_size() == (64, 64)
+    pygame.quit()
+
+
+def test_player_health_mana_usage():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    player = PlayerCharacter(0, 0)
+    player.take_damage(30)
+    assert player.health == 70
+    assert player.use_mana(20)
+    assert player.mana == 80
+    assert not player.use_mana(100)
+    pygame.quit()
+
+
+def test_draw_status_updates_surface():
+    pygame.init()
+    screen = pygame.display.set_mode((120, 50))
+    player = PlayerCharacter(0, 0)
+    player.health = 50
+    player.mana = 25
+    player.draw_status(screen)
+    # Check a pixel within the health bar is green when half health
+    assert screen.get_at((15, 10))[:3] == (0, 255, 0)
+    # Mana bar should have blue pixel when quarter mana
+    assert screen.get_at((15, 25))[:3] == (0, 0, 255)
+    pygame.quit()
+
+
+def test_melee_attack_and_block():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    player = PlayerCharacter(0, 0)
+    now = pygame.time.get_ticks()
+    attack = player.melee_attack(now)
+    assert attack is not None
+    # Cooldown prevents immediate second attack
+    assert player.melee_attack(now) is None
+    player.blocking = True
+    player.health = 100
+    player.take_damage(20)
+    assert player.health == 90  # half damage when blocking
+    pygame.quit()
+
+
+def test_parry_prevents_damage():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    player = PlayerCharacter(0, 0)
+    now = pygame.time.get_ticks()
+    assert player.parry(now)
+    player.take_damage(50)
+    assert player.health == player.max_health
+    player.update(1000, now + 300)
+    player.take_damage(50)
+    assert player.health == player.max_health - 50
+    pygame.quit()
+
+
+def test_gura_special_attack():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.player import GuraPlayer
+
+    player = GuraPlayer(0, 0)
+    now = pygame.time.get_ticks()
+    proj = player.special_attack(now)
+    assert proj is not None
+    assert player.mana < player.max_mana
+    assert player.special_attack(now) is None  # cooldown active
+    pygame.quit()
+
+
+def test_watson_special_dash():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.player import WatsonPlayer
+
+    player = WatsonPlayer(0, 0)
+    now = pygame.time.get_ticks()
+    player.velocity.x = 0
+    player.special_attack(now)
+    assert player.velocity.x != 0
+    assert player.mana < player.max_mana
+    pygame.quit()
+
+
+def test_ina_grapple_projectile(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.save_manager.SAVE_DIR', tmp_path)
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    game.selected_character = "Ninomae Ina'nis"
+    game.ai_players = 1
+    game._setup_level()
+    enemy = next(iter(game.enemies))
+    now = pygame.time.get_ticks()
+    proj = game.player.special_attack(now)
+    assert proj is not None
+    proj.rect.center = enemy.rect.center
+    game.projectiles.add(proj)
+    game.all_sprites.add(proj)
+    game._handle_collisions()
+    assert enemy.rect.centerx == game.player.rect.centerx
+    pygame.quit()
+
+
+def test_player_lives_decrease():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    player = PlayerCharacter(0, 0)
+    player.take_damage(200)
+    assert player.lives == 2
+    pygame.quit()
+
+
+def test_fubuki_freeze_special():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.player import FubukiPlayer, Enemy
+    from hololive_coliseum.projectile import FreezingProjectile
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    player = FubukiPlayer(0, 0)
+    enemy = Enemy(60, 0)
+    enemy.velocity.x = 2
+    game.player = player
+    game.enemies = pygame.sprite.Group(enemy)
+    proj = player.special_attack(pygame.time.get_ticks())
+    assert isinstance(proj, FreezingProjectile)
+    proj.rect.center = enemy.rect.center
+    game.projectiles = pygame.sprite.Group(proj)
+    game.melee_attacks = pygame.sprite.Group()
+    game.all_sprites = pygame.sprite.Group(player, enemy, proj)
+    game._handle_collisions()
+    assert enemy.velocity.x == 1
+    assert enemy.health == enemy.max_health - 5
+    pygame.quit()
+
+
+def test_mumei_flock_special():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.player import MumeiPlayer, Enemy
+    from hololive_coliseum.projectile import FlockProjectile
+    from hololive_coliseum.game import Game
+
+    player = MumeiPlayer(0, 0)
+    enemy = Enemy(60, 0)
+    enemy.velocity.x = 2
+    game = Game()
+    game.player = player
+    proj = player.special_attack(pygame.time.get_ticks())
+    assert isinstance(proj, FlockProjectile)
+    proj.rect.center = enemy.rect.center
+    game.enemies = pygame.sprite.Group(enemy)
+    game.projectiles = pygame.sprite.Group(proj)
+    game.melee_attacks = pygame.sprite.Group()
+    game.all_sprites = pygame.sprite.Group(player, enemy, proj)
+    game._handle_collisions()
+    assert enemy.velocity.x == 1
+    assert enemy.health == enemy.max_health - 5
+    pygame.quit()
+
+
+def test_fauna_healing_zone():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.player import FaunaPlayer
+    from hololive_coliseum.healing_zone import HealingZone
+
+    player = FaunaPlayer(0, 0)
+    player.health = 50
+    zone = player.special_attack(pygame.time.get_ticks())
+    assert isinstance(zone, HealingZone)
+    # Player stands in the zone and should heal
+    if zone.rect.colliderect(player.rect):
+        player.health = min(player.max_health, player.health + zone.heal_rate)
+    assert player.health > 50
+    pygame.quit()
+
+
+def test_player_dodge():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    player = PlayerCharacter(0, 0)
+    now = pygame.time.get_ticks()
+    assert player.dodge(now, 1)
+    assert player.dodging
+    player.update(1000, now + 300)
+    assert not player.dodging
+    pygame.quit()
+
+
+def test_calliope_boomerang_projectile():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.player import CalliopePlayer
+    from hololive_coliseum.projectile import BoomerangProjectile
+
+    player = CalliopePlayer(0, 0)
+    now = pygame.time.get_ticks()
+    proj = player.special_attack(now)
+    assert isinstance(proj, BoomerangProjectile)
+    right_vel = proj.velocity.x
+    for _ in range(16):
+        proj.update()
+    assert proj.velocity.x != right_vel
+    assert proj.velocity.x < 0  # now returning toward player
+    pygame.quit()
+
+
+def test_kiara_dive_explosion(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.save_manager.SAVE_DIR', tmp_path)
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.game import Game
+    from hololive_coliseum.player import KiaraPlayer, Enemy
+
+    game = Game()
+    game.player = KiaraPlayer(0, game.ground_y - 60)
+    enemy = Enemy(10, game.ground_y - 60)
+    game.enemies = pygame.sprite.Group(enemy)
+    game.projectiles = pygame.sprite.Group()
+    game.melee_attacks = pygame.sprite.Group()
+    game.all_sprites = pygame.sprite.Group(game.player, enemy)
+    now = pygame.time.get_ticks()
+    game.player.special_attack(now)
+    extra = None
+    for i in range(80):
+        extra = game.player.update(game.ground_y, now + 50 * i)
+        if extra:
+            game.projectiles.add(extra)
+            game.all_sprites.add(extra)
+            break
+    game.projectiles.update()
+    game._handle_collisions()
+    assert enemy.health < enemy.max_health
+    pygame.quit()
+
+
+def test_irys_shield_blocks_projectile(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.save_manager.SAVE_DIR', tmp_path)
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.game import Game
+    from hololive_coliseum.player import IRySPlayer, Enemy
+    from hololive_coliseum.projectile import Projectile
+
+    game = Game()
+    game.player = IRySPlayer(0, 0)
+    enemy = Enemy(60, 0)
+    proj = Projectile(game.player.rect.centerx, game.player.rect.centery, pygame.math.Vector2(0, 0), True)
+    game.enemies = pygame.sprite.Group(enemy)
+    game.projectiles = pygame.sprite.Group(proj)
+    game.melee_attacks = pygame.sprite.Group()
+    game.all_sprites = pygame.sprite.Group(game.player, proj)
+    game.player.special_attack(pygame.time.get_ticks())
+    health = game.player.health
+    game._handle_collisions()
+    assert game.player.health == health
+    assert not proj.alive()
+    pygame.quit()
+
+
+def test_miko_piercing_beam():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.player import MikoPlayer, Enemy
+    from hololive_coliseum.projectile import PiercingProjectile
+    from hololive_coliseum.game import Game
+
+    player = MikoPlayer(0, 0)
+    enemy = Enemy(60, 0)
+    game = Game()
+    game.player = player
+    game.enemies = pygame.sprite.Group(enemy)
+    proj = player.special_attack(pygame.time.get_ticks())
+    assert isinstance(proj, PiercingProjectile)
+    proj.rect.center = enemy.rect.center
+    game.projectiles = pygame.sprite.Group(proj)
+    game.melee_attacks = pygame.sprite.Group()
+    game.all_sprites = pygame.sprite.Group(player, enemy, proj)
+    game._handle_collisions()
+    assert proj.alive()  # piercing projectile remains
+    assert enemy.health == enemy.max_health - 10
+    pygame.quit()
+
+
+def test_player_double_jump():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    player = PlayerCharacter(0, 0)
+    dummy_keys = type('D', (), {'__getitem__': lambda self, key: False})()
+    now = pygame.time.get_ticks()
+    # first jump from ground
+    player.handle_input(dummy_keys, now, action_pressed=lambda a: a == "jump")
+    player.update(1000, now + 50)
+    assert player.jump_count == 1
+    # second jump mid-air
+    player.handle_input(dummy_keys, now + 60, action_pressed=lambda a: a == "jump")
+    player.update(1000, now + 120)
+    assert player.jump_count == 2
+    # attempt third jump should fail
+    player.handle_input(dummy_keys, now + 130, action_pressed=lambda a: a == "jump")
+    assert player.jump_count == 2
+    pygame.quit()
+
+
+def test_sora_special_projectile():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.player import SoraPlayer
+    from hololive_coliseum.projectile import ExplodingProjectile
+
+    player = SoraPlayer(0, 0)
+    proj = player.special_attack(pygame.time.get_ticks())
+    assert isinstance(proj, ExplodingProjectile)
+    pygame.quit()
+
+
+def test_aqua_special_projectile():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.player import AquaPlayer
+    from hololive_coliseum.projectile import ExplodingProjectile
+
+    player = AquaPlayer(0, 0)
+    proj = player.special_attack(pygame.time.get_ticks())
+    assert isinstance(proj, ExplodingProjectile)
+    pygame.quit()
+
+
+def test_pekora_special_projectile():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.player import PekoraPlayer
+    from hololive_coliseum.projectile import ExplodingProjectile
+
+    player = PekoraPlayer(0, 0)
+    proj = player.special_attack(pygame.time.get_ticks())
+    assert isinstance(proj, ExplodingProjectile)
+    pygame.quit()
+
+
+def test_marine_special_boomerang():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.player import MarinePlayer
+    from hololive_coliseum.projectile import BoomerangProjectile
+
+    player = MarinePlayer(0, 0)
+    proj = player.special_attack(pygame.time.get_ticks())
+    assert isinstance(proj, BoomerangProjectile)
+    pygame.quit()
+
+
+def test_suisei_special_piercing():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.player import SuiseiPlayer
+    from hololive_coliseum.projectile import PiercingProjectile
+
+    player = SuiseiPlayer(0, 0)
+    proj = player.special_attack(pygame.time.get_ticks())
+    assert isinstance(proj, PiercingProjectile)
+    pygame.quit()
+
+
+def test_ayame_special_dash():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.player import AyamePlayer
+
+    player = AyamePlayer(0, 0)
+    now = pygame.time.get_ticks()
+    player.special_attack(now)
+    assert player.velocity.x != 0
+    pygame.quit()
+
+
+def test_noel_special_explosion():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.player import NoelPlayer
+    from hololive_coliseum.projectile import ExplosionProjectile
+
+    player = NoelPlayer(0, 0)
+    proj = player.special_attack(pygame.time.get_ticks())
+    assert isinstance(proj, ExplosionProjectile)
+    pygame.quit()
+
+
+def test_flare_special_exploding():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.player import FlarePlayer
+    from hololive_coliseum.projectile import ExplodingProjectile
+
+    player = FlarePlayer(0, 0)
+    proj = player.special_attack(pygame.time.get_ticks())
+    assert isinstance(proj, ExplodingProjectile)
+    pygame.quit()
+
+
+def test_subaru_special_exploding():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.player import SubaruPlayer
+    from hololive_coliseum.projectile import ExplodingProjectile
+
+    player = SubaruPlayer(0, 0)
+    proj = player.special_attack(pygame.time.get_ticks())
+    assert isinstance(proj, ExplodingProjectile)
+    pygame.quit()

--- a/tests/test_progress_managers.py
+++ b/tests/test_progress_managers.py
@@ -1,0 +1,24 @@
+from hololive_coliseum.quest_manager import QuestManager
+from hololive_coliseum.achievement_manager import AchievementManager
+
+
+def test_quest_manager_basic():
+    qm = QuestManager()
+    qm.add('q1', 'Collect things')
+    qm.update_progress('q1', 2)
+    assert qm.get_progress('q1') == 2
+    qm.complete('q1')
+    assert qm.is_completed('q1')
+    assert 'q1' not in qm.active
+
+
+def test_achievement_manager_roundtrip():
+    am = AchievementManager()
+    am.unlock('first')
+    assert am.is_unlocked('first')
+    data = am.to_dict()
+    am.unlock('second')
+    am.load_from_dict(data)
+    assert am.is_unlocked('first')
+    assert not am.is_unlocked('second')
+

--- a/tests/test_projectile.py
+++ b/tests/test_projectile.py
@@ -1,0 +1,67 @@
+import os
+import sys
+
+# Unit tests covering projectile and melee behavior.
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import pygame
+from hololive_coliseum.projectile import Projectile, PROJECTILE_SPEED
+from hololive_coliseum.melee_attack import MeleeAttack, MELEE_LIFETIME
+
+
+def test_projectile_moves():
+    direction = pygame.math.Vector2(1, 0)
+    proj = Projectile(0, 0, direction)
+    orig_x = proj.rect.x
+    proj.update()
+    assert proj.rect.x == orig_x + PROJECTILE_SPEED
+
+
+def test_projectile_aims_toward_target():
+    direction = pygame.math.Vector2(10, 0)
+    proj = Projectile(0, 0, direction)
+    assert proj.velocity.x > 0 and proj.velocity.y == 0
+
+
+def test_melee_attack_lifetime():
+    attack = MeleeAttack(0, 0, 1)
+    for _ in range(MELEE_LIFETIME):
+        attack.update()
+    # Should be killed after lifetime expires
+    assert not attack.alive()
+
+
+def test_player_shoot_zero_vector(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.save_manager.SAVE_DIR', tmp_path)
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.player import PlayerCharacter
+
+    player = PlayerCharacter(0, 0)
+    player.last_shot = -1000
+    now = pygame.time.get_ticks()
+    proj = player.shoot(now, player.rect.center)
+    assert proj is not None
+    assert proj.velocity.x == PROJECTILE_SPEED
+    assert proj.velocity.y == 0
+    pygame.quit()
+
+
+def test_projectile_hits_enemy(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.save_manager.SAVE_DIR', tmp_path)
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    from hololive_coliseum.game import Game
+
+    game = Game()
+    game.ai_players = 1
+    game._setup_level()
+    enemy = next(iter(game.enemies))
+    proj = Projectile(enemy.rect.centerx, enemy.rect.centery, pygame.math.Vector2(0, 0))
+    game.projectiles.add(proj)
+    game.all_sprites.add(proj)
+    game._handle_collisions()
+    assert enemy.health < enemy.max_health
+    pygame.quit()

--- a/tests/test_resource_managers.py
+++ b/tests/test_resource_managers.py
@@ -1,0 +1,75 @@
+from hololive_coliseum.health_manager import HealthManager
+from hololive_coliseum.mana_manager import ManaManager
+from hololive_coliseum.equipment_manager import EquipmentManager
+from hololive_coliseum.inventory_manager import InventoryManager
+from hololive_coliseum.keybind_manager import KeybindManager
+from hololive_coliseum.stats_manager import StatsManager
+from hololive_coliseum.experience_manager import ExperienceManager
+
+
+def test_health_manager_basic():
+    mgr = HealthManager(100)
+    assert mgr.take_damage(30) == 70
+    assert mgr.heal(20) == 90
+    assert mgr.take_damage(200) == 0
+
+
+def test_mana_manager_usage():
+    mgr = ManaManager(50)
+    assert mgr.use(20)
+    assert mgr.mana == 30
+    assert not mgr.use(40)
+    mgr.regen(10)
+    assert mgr.mana == 40
+
+
+def test_equipment_manager():
+    mgr = EquipmentManager()
+    mgr.equip("weapon", "Sword")
+    assert mgr.get("weapon") == "Sword"
+    mgr.unequip("weapon")
+    assert mgr.get("weapon") is None
+
+
+def test_inventory_manager_add_remove():
+    mgr = InventoryManager()
+    mgr.add("Potion")
+    assert mgr.has("Potion")
+    assert mgr.count("Potion") == 1
+    mgr.add("Potion", 2)
+    assert mgr.count("Potion") == 3
+    assert mgr.remove("Potion", 2)
+    assert mgr.count("Potion") == 1
+    assert mgr.remove("Potion")
+    assert not mgr.has("Potion")
+
+
+def test_keybind_manager_basic():
+    defaults = {"jump": 32}
+    mgr = KeybindManager(defaults)
+    assert mgr.get("jump") == 32
+    mgr.set("jump", 10)
+    assert mgr.get("jump") == 10
+    saved = mgr.to_dict()
+    mgr.set("shoot", 5)
+    mgr.load_from_dict(saved)
+    assert "shoot" not in mgr.bindings
+    mgr.reset()
+    assert mgr.get("jump") == 32
+
+
+def test_stats_manager_modifiers():
+    mgr = StatsManager({"str": 10, "dex": 5})
+    assert mgr.get("str") == 10
+    mgr.apply_modifier("str", 5)
+    assert mgr.get("str") == 15
+    mgr.remove_modifier("str", 3)
+    assert mgr.get("str") == 12
+
+
+def test_experience_manager_levels():
+    mgr = ExperienceManager(level=1, xp=90, threshold=100)
+    assert not mgr.add_xp(5)
+    assert mgr.level == 1 and mgr.xp == 95
+    assert mgr.add_xp(10)
+    assert mgr.level == 2 and mgr.xp == 5

--- a/tests/test_save_manager.py
+++ b/tests/test_save_manager.py
@@ -1,0 +1,68 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from hololive_coliseum import save_settings, load_settings, wipe_saves, merge_records
+
+
+def test_save_and_load_settings(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.save_manager.SAVE_DIR', tmp_path)
+    os.makedirs(tmp_path, exist_ok=True)
+    data = {"width": 123}
+    save_settings(data)
+    assert load_settings() == data
+    wipe_saves()
+    assert load_settings() == {}
+
+
+def test_load_settings_handles_corrupt_file(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.save_manager.SAVE_DIR', tmp_path)
+    os.makedirs(tmp_path, exist_ok=True)
+    path = tmp_path / 'settings.json'
+    path.write_text('{bad json')
+    assert load_settings() == {}
+
+
+def test_save_creates_directory(tmp_path, monkeypatch):
+    target_dir = tmp_path / 'nested'
+    monkeypatch.setattr('hololive_coliseum.save_manager.SAVE_DIR', target_dir)
+    data = {"test": True}
+    save_settings(data)
+    assert (target_dir / 'settings.json').exists()
+
+
+def test_wipe_saves_missing_dir(tmp_path, monkeypatch):
+    target_dir = tmp_path / 'missing'
+    monkeypatch.setattr('hololive_coliseum.save_manager.SAVE_DIR', target_dir)
+    # Directory does not exist yet
+    wipe_saves()  # should recreate directory without error
+    assert target_dir.exists()
+
+
+def test_wipe_saves_removes_subdirs(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.save_manager.SAVE_DIR', tmp_path)
+    sub = tmp_path / 'subdir'
+    sub.mkdir()
+    (sub / 'file.txt').write_text('x')
+    wipe_saves()
+    assert not sub.exists()
+
+def test_merge_records(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.save_manager.SAVE_DIR', tmp_path)
+    os.makedirs(tmp_path, exist_ok=True)
+    save_settings({'best_time': 10, 'best_score': 5})
+    merge_records({'best_time': 8, 'best_score': 6})
+    data = load_settings()
+    assert data['best_time'] == 10 and data['best_score'] == 6
+    merge_records({'best_time': 12, 'best_score': 4})
+    data = load_settings()
+    assert data['best_time'] == 12 and data['best_score'] == 6
+
+def test_merge_records_longer_time(tmp_path, monkeypatch):
+    monkeypatch.setattr('hololive_coliseum.save_manager.SAVE_DIR', tmp_path)
+    os.makedirs(tmp_path, exist_ok=True)
+    save_settings({'best_time': 5})
+    merge_records({'best_time': 7})
+    data = load_settings()
+    assert data['best_time'] == 7

--- a/tests/test_skill_manager.py
+++ b/tests/test_skill_manager.py
@@ -1,0 +1,19 @@
+import pygame
+from hololive_coliseum.skill_manager import SkillManager
+
+
+def test_skill_manager_cooldown():
+    pygame.init()
+    manager = SkillManager()
+    calls = []
+
+    def ability(now):
+        calls.append(now)
+        return "ok"
+
+    manager.register("special", 100, ability)
+    now = pygame.time.get_ticks()
+    assert manager.use("special", now) == "ok"
+    assert manager.use("special", now + 50) is None
+    assert manager.use("special", now + 150) == "ok"
+    pygame.quit()

--- a/tests/test_social_managers.py
+++ b/tests/test_social_managers.py
@@ -1,0 +1,48 @@
+from hololive_coliseum.currency_manager import CurrencyManager
+from hololive_coliseum.title_manager import TitleManager
+from hololive_coliseum.reputation_manager import ReputationManager
+from hololive_coliseum.friend_manager import FriendManager
+from hololive_coliseum.guild_manager import GuildManager
+from hololive_coliseum.mail_manager import MailManager
+
+
+def test_currency_manager():
+    cm = CurrencyManager(10)
+    cm.add(5)
+    assert cm.get_balance() == 15
+    assert cm.spend(7)
+    assert cm.get_balance() == 8
+    assert not cm.spend(20)
+
+
+def test_title_and_reputation():
+    tm = TitleManager()
+    tm.unlock("Hero")
+    assert tm.set_active("Hero")
+    assert tm.get_active() == "Hero"
+    rm = ReputationManager()
+    assert rm.get("f") == 0
+    rm.modify("f", 5)
+    assert rm.get("f") == 5
+
+
+def test_friend_and_guild():
+    fm = FriendManager()
+    fm.add_friend("alice")
+    assert fm.is_friend("alice")
+    fm.remove_friend("alice")
+    assert not fm.list_friends()
+    gm = GuildManager()
+    gm.add_member("bob")
+    gm.set_rank("bob", "leader")
+    assert gm.get_rank("bob") == "leader"
+    gm.remove_member("bob")
+    assert gm.list_members() == {}
+
+
+def test_mail_manager():
+    mm = MailManager()
+    mm.send_mail("c", "hi")
+    assert mm.inbox("c") == ["hi"]
+    mm.clear("c")
+    assert mm.inbox("c") == []

--- a/tests/test_status_effects.py
+++ b/tests/test_status_effects.py
@@ -1,0 +1,22 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import pygame
+from hololive_coliseum.player import Enemy
+from hololive_coliseum.status_effects import StatusEffectManager, FreezeEffect
+
+
+def test_freeze_effect_expires():
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    enemy = Enemy(0, 0)
+    manager = StatusEffectManager()
+    enemy.velocity.x = 4
+    manager.add_effect(enemy, FreezeEffect(duration_ms=50))
+    assert enemy.speed_factor == 0.5
+    now = pygame.time.get_ticks() + 60
+    manager.update(now)
+    assert enemy.speed_factor == 1.0
+    pygame.quit()

--- a/tests/test_world_managers.py
+++ b/tests/test_world_managers.py
@@ -1,0 +1,52 @@
+from hololive_coliseum.map_manager import MapManager
+from hololive_coliseum.environment_manager import EnvironmentManager
+from hololive_coliseum.spawn_manager import SpawnManager
+from hololive_coliseum.event_manager import EventManager
+from hololive_coliseum.dungeon_manager import DungeonManager
+from hololive_coliseum.housing_manager import HousingManager
+from hololive_coliseum.mount_manager import MountManager
+from hololive_coliseum.pet_manager import PetManager
+from hololive_coliseum.companion_manager import CompanionManager
+
+
+def test_map_and_environment():
+    mm = MapManager()
+    mm.add_map("m1", {})
+    assert mm.set_current("m1")
+    assert mm.get_current() == {}
+    env = EnvironmentManager()
+    env.set("weather", "rain")
+    assert env.get("weather") == "rain"
+
+
+def test_spawn_and_event_manager():
+    sm = SpawnManager()
+    sm.schedule("orc", 5)
+    assert not sm.get_ready(4)
+    assert sm.get_ready(5) == ["orc"]
+    em = EventManager()
+    em.trigger("boss")
+    assert em.get_history() == ["boss"]
+
+
+def test_dungeon_and_housing():
+    dm = DungeonManager()
+    dm.set_lockout("p", "d", 10)
+    assert not dm.can_enter("p", "d", 9)
+    assert dm.can_enter("p", "d", 11)
+    hm = HousingManager()
+    hm.add_house("p", {"rooms": 1})
+    assert hm.get_house("p") == {"rooms": 1}
+
+
+def test_mount_pet_companion():
+    mm = MountManager()
+    mm.add_mount("p", "horse")
+    assert mm.set_active("p", "horse")
+    assert mm.get_active("p") == "horse"
+    pm = PetManager()
+    pm.add_pet("p", "cat")
+    assert pm.list_pets("p") == ["cat"]
+    cm = CompanionManager()
+    cm.assign("p", "guide")
+    assert cm.get("p") == "guide"


### PR DESCRIPTION
## Summary
- extend `ChatManager` with open/close state and message limit
- describe the chat box in the README and project docs
- log the change in dev notes and plans
- update additional manager tests for new behaviour
- integrate chat manager with Game so Enter opens a chat box
- track typed chat text and send message on Enter
- update dev notes, plan, goals
- test chat toggle and send

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d014bb448321904a7cffa88c6c5e